### PR TITLE
fix for note title not displaying when the first character is new line

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,15 +1,15 @@
 import { NoteItem } from 'types'
 
 export function getNoteTitle(text: string): string {
+  const noteTitleRegEx = /[\w ]{1,50}/
+
   let noteTitle: string
-  let noteText = text[0] === '#' && text[1] === ' ' ? text.slice(2, 52) : text.slice(0, 50)
+  let noteText = text.match(noteTitleRegEx)
 
   if (!noteText) {
     noteTitle = 'New Note'
-  } else if (noteText.indexOf('\n') !== -1) {
-    noteTitle = noteText.slice(0, noteText.indexOf('\n'))
   } else {
-    noteTitle = noteText.slice(0, 50)
+    noteTitle = noteText[0]
   }
 
   return noteTitle

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,7 +1,7 @@
 import { NoteItem } from 'types'
 
 export function getNoteTitle(text: string): string {
-  const noteTitleRegEx = /[\w' ]{1,50}/
+  const noteTitleRegEx = /[\w'?!. ]{1,50}/
 
   let noteTitle: string
   let noteText = text.match(noteTitleRegEx)

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,7 +1,7 @@
 import { NoteItem } from 'types'
 
 export function getNoteTitle(text: string): string {
-  const noteTitleRegEx = /[\w ]{1,50}/
+  const noteTitleRegEx = /[\w' ]{1,50}/
 
   let noteTitle: string
   let noteText = text.match(noteTitleRegEx)


### PR DESCRIPTION
I replaced the splicing of the note text with a regular expression that matches a-z, A-Z,0-9, and spaces. If any more characters need to be matched so they can show in the note title we can add them to the regular expression pretty easy I think. 

#20 