### PR TITLE
Use absolute URL for issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm start
 
 ## Contributing
 
-TakeNote is an open source project, and contributions of any kind are welcome! Open issues, bugs, and enhancements are all listed on the [issues](/issues) tab and labeled accordingly. Feel free to open bug tickets and make feature requests. Easy bugs and features will be tagged with the `good first issue` label.
+TakeNote is an open source project, and contributions of any kind are welcome! Open issues, bugs, and enhancements are all listed on the [issues](https://github.com/taniarascia/takenote/issues) tab and labeled accordingly. Feel free to open bug tickets and make feature requests. Easy bugs and features will be tagged with the `good first issue` label.
 
 The project is written in TypeScript, React and Redux. TypeScript is set to strict mode, with no implicit any allowed. The formatting style for the project is set by Prettier.
 


### PR DESCRIPTION
The issues link isn't part of the codebase, so until GitHub provides a shortlink for it, best to use an absolute URL, as Issues isn't relative to anything.

Thanks to @opw0011 for catching this / making PR #41.