### PR TITLE
Forgot brackets

### DIFF
--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -16,8 +16,8 @@ const App: React.FC = () => {
 
   const dispatch = useDispatch()
 
-  const _loadNotes = () => dispatch(loadNotes())
-  const _loadCategories = () => dispatch(loadCategories())
+  const _loadNotes = () => { dispatch(loadNotes()) }
+  const _loadCategories = () => { dispatch(loadCategories()) }
 
   useEffect(_loadNotes, [])
   useEffect(_loadCategories, [])


### PR DESCRIPTION
Fixing a small bug I introduced with useEffect on App.tsx.  Forgot brackets >.>;