### PR TITLE
category name duplicate and length error messages

### DIFF
--- a/src/containers/AppSidebar.tsx
+++ b/src/containers/AppSidebar.tsx
@@ -59,7 +59,12 @@ const AppSidebar: React.FC = () => {
   const _addCategoryToNote = (categoryId: string, noteId: string) =>
     dispatch(addCategoryToNote({ categoryId, noteId }))
 
-  const { addingTempCategory, setAddingTempCategory } = useKeyboard()
+  const {
+    errorCategoryMessage,
+    setErrorCategoryMessage,
+    addingTempCategory,
+    setAddingTempCategory,
+  } = useKeyboard()
   const [tempCategory, setTempCategory] = useState('')
   const { syncing } = useSelector((state: RootState) => state.syncState)
 
@@ -83,11 +88,16 @@ const AppSidebar: React.FC = () => {
 
     const category = { id: kebabCase(tempCategory), name: tempCategory }
 
-    if (!categories.find(cat => cat.id === kebabCase(tempCategory))) {
+    if (category.name.length > 20) {
+      setErrorCategoryMessage('Category name must not exceed 20 characters')
+    } else if (categories.find(cat => cat.id === kebabCase(tempCategory))) {
+      setErrorCategoryMessage('Category name has already been added')
+    } else {
       _addCategory(category)
 
       setTempCategory('')
       setAddingTempCategory(false)
+      setErrorCategoryMessage('')
     }
   }
 
@@ -222,6 +232,9 @@ const AppSidebar: React.FC = () => {
           </button>
         </div>
         <div className="category-list">
+          <div className="category-error-message">
+            {errorCategoryMessage && <span>{errorCategoryMessage}</span>}
+          </div>
           {categories.map(category => {
             return (
               <div

--- a/src/containers/SettingsModal.tsx
+++ b/src/containers/SettingsModal.tsx
@@ -67,31 +67,31 @@ const SettingsModal: React.FC = () => {
           <div className="settings-shortcut">
             <div>Create note</div>
             <div>
-              <kbd>ALT</kbd> + <kbd>CTRL</kbd> + <kbd>N</kbd>
+              <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>N</kbd>
             </div>
           </div>
           <div className="settings-shortcut">
             <div>Delete note</div>
             <div>
-              <kbd>ALT</kbd> + <kbd>CTRL</kbd> + <kbd>W</kbd>
+              <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>W</kbd>
             </div>
           </div>
           <div className="settings-shortcut">
             <div>Create category</div>
             <div>
-              <kbd>ALT</kbd> + <kbd>CTRL</kbd> + <kbd>C</kbd>
+              <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>C</kbd>
             </div>
           </div>
           <div className="settings-shortcut">
             <div>Download note</div>
             <div>
-              <kbd>ALT</kbd> + <kbd>CTRL</kbd> + <kbd>D</kbd>
+              <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>D</kbd>
             </div>
           </div>
           <div className="settings-shortcut">
             <div>Sync note</div>
             <div>
-              <kbd>ALT</kbd> + <kbd>CTRL</kbd> + <kbd>S</kbd>
+              <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>S</kbd>
             </div>
           </div>
         </section>

--- a/src/contexts/KeyboardContext.tsx
+++ b/src/contexts/KeyboardContext.tsx
@@ -3,11 +3,15 @@ import React, { createContext, FunctionComponent, useContext, useState } from 'r
 interface KeyboardContextInterface {
   addingTempCategory: boolean
   setAddingTempCategory(adding: boolean): void
+  errorCategoryMessage: string
+  setErrorCategoryMessage(message: string): void
 }
 
 const initialContextValue = {
+  errorCategoryMessage: '',
   addingTempCategory: false,
   setAddingTempCategory: (adding: boolean) => undefined,
+  setErrorCategoryMessage: (message: string) => undefined,
 }
 
 const KeyboardContext = createContext<KeyboardContextInterface>(initialContextValue)
@@ -20,9 +24,12 @@ const useKeyboard = () => {
 }
 const KeyboardProvider: FunctionComponent = ({ children }) => {
   const [addingTempCategory, setAddingTempCategory] = useState(false)
+  const [errorCategoryMessage, setErrorCategoryMessage] = useState('')
   const value: KeyboardContextInterface = {
     addingTempCategory,
     setAddingTempCategory,
+    errorCategoryMessage,
+    setErrorCategoryMessage,
   }
   return <KeyboardContext.Provider value={value}>{children}</KeyboardContext.Provider>
 }

--- a/src/styles/_app-sidebar.scss
+++ b/src/styles/_app-sidebar.scss
@@ -80,6 +80,13 @@
       padding: 0.5rem;
     }
 
+    &-error-message {
+      display: flex;
+      text-align: center;
+      margin: 0 10px;
+      color: red;
+    }
+
     &-list {
       font-size: 0.9rem;
 


### PR DESCRIPTION
Resolves #70 and #71 

Styling may be in need of changing, but the general logic is there to determine if the length is greater than 20 or duplicates

Duplicate category
![Screen Shot 2019-10-16 at 12 43 28 AM](https://user-images.githubusercontent.com/23242741/66894772-7eab1500-efae-11e9-95f9-cfaf51261581.png)

Over length of 20
![Screen Shot 2019-10-16 at 12 46 21 AM](https://user-images.githubusercontent.com/23242741/66894801-8b2f6d80-efae-11e9-99e6-9920acdd3886.png)
