### PR TITLE
fix(keyboard-shortcuts): dispatch CodeMirror theme change with DarkMode shortcut

### DIFF
--- a/src/containers/KeyboardShortcuts.tsx
+++ b/src/containers/KeyboardShortcuts.tsx
@@ -8,12 +8,14 @@ import { addNote, swapNote, toggleTrashedNote } from 'slices/note'
 import { syncState } from 'slices/sync'
 import { toggleDarkTheme } from 'slices/theme'
 import { RootState, CategoryItem, NoteItem } from 'types'
+import { updateCodeMirrorOption } from 'slices/settings'
 
 const KeyboardShortcuts: React.FC = () => {
   const { categories } = useSelector((state: RootState) => state.categoryState)
   const { activeCategoryId, activeFolder, activeNoteId, notes } = useSelector(
     (state: RootState) => state.noteState
   )
+  const { dark } = useSelector((state: RootState) => state.themeState)
 
   const activeNote = notes.find(note => note.id === activeNoteId)
 
@@ -25,6 +27,8 @@ const KeyboardShortcuts: React.FC = () => {
   const _syncState = (notes: NoteItem[], categories: CategoryItem[]) =>
     dispatch(syncState({ notes, categories }))
   const _toggleDarkTheme = () => dispatch(toggleDarkTheme())
+  const _updateCodeMirrorOption = (key: string, value: string) =>
+    dispatch(updateCodeMirrorOption({ key, value }))
 
   const { addingTempCategory, setAddingTempCategory } = useTempState()
   const newNoteHandler = () => {
@@ -58,6 +62,7 @@ const KeyboardShortcuts: React.FC = () => {
 
   const toggleDarkThemeHandler = () => {
     _toggleDarkTheme()
+    _updateCodeMirrorOption('theme', dark ? 'base16-light' : 'zenburn')
   }
 
   useKey('alt+ctrl+n', () => {

--- a/src/containers/SettingsModal.tsx
+++ b/src/containers/SettingsModal.tsx
@@ -92,6 +92,12 @@ const SettingsModal: React.FC = () => {
               <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>S</kbd>
             </div>
           </div>
+          <div className="settings-shortcut">
+            <div>Dark mode</div>
+            <div>
+              <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>T</kbd>
+            </div>
+          </div>
         </section>
       </div>
     </div>


### PR DESCRIPTION
Resolves: #85 

toggling dark theme using kb shortcut was introducing inconsistent ui, leaving editor in bright color.

I've also added the shortcut to keyboard shortcuts list.

Let me know if this approach is enough, not sure if duplicating same stuff is the best way to solve this.