### PR TITLE
add check:  category name cannot be space or spaces

### DIFF
--- a/src/containers/AppSidebar.tsx
+++ b/src/containers/AppSidebar.tsx
@@ -92,7 +92,9 @@ const AppSidebar: React.FC = () => {
 
     const category = { id: kebabCase(tempCategory), name: tempCategory }
 
-    if (category.name.length > 20) {
+    if (category.name.trim().length === 0) {
+      setErrorCategoryMessage('Category name is invalid')
+    } else if (category.name.length > 20) {
       setErrorCategoryMessage('Category name must not exceed 20 characters')
     } else if (categories.find(cat => cat.id === kebabCase(tempCategory))) {
       setErrorCategoryMessage('Category name has already been added')


### PR DESCRIPTION
with ref: closed-83
In previous closed PR, I forgot to mention that category name cannot be a single `space` or `spaces`. I hope this time it will make sense. 
Check out screenshot below.
[Example Takenote](https://www.dropbox.com/s/e7q43jym0jh2elh/takenote1.png?dl=0)
**Note**: If we will allow `space` as category name, it does not show in the `select`.