### PR TITLE
Feature added - Detect when vim is in edit mode

### DIFF
--- a/src/containers/NoteEditor.tsx
+++ b/src/containers/NoteEditor.tsx
@@ -4,7 +4,8 @@ import { Controlled as CodeMirror } from 'react-codemirror2'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { updateNote } from 'slices/note'
-import { RootState, NoteItem } from 'types'
+import { updateVimStateMode } from 'slices/settings'
+import { RootState, NoteItem, VimModes } from 'types'
 
 import 'codemirror/lib/codemirror.css'
 import 'codemirror/theme/base16-light.css'
@@ -15,13 +16,15 @@ import 'codemirror/keymap/vim'
 
 const NoteEditor: React.FC = () => {
   const { activeNoteId, loading, notes } = useSelector((state: RootState) => state.noteState)
-  const { codeMirrorOptions } = useSelector((state: RootState) => state.settingsState)
+  const { codeMirrorOptions, vimState } = useSelector((state: RootState) => state.settingsState)
 
   const activeNote = notes.find(note => note.id === activeNoteId)
 
   const dispatch = useDispatch()
 
   const _updateNote = (note: NoteItem) => dispatch(updateNote(note))
+
+  const _updateVimStateMode = (vimMode: VimModes) => dispatch(updateVimStateMode(vimMode))
 
   if (loading) {
     return <div className="empty-editor v-center">Loading...</div>
@@ -34,12 +37,17 @@ const NoteEditor: React.FC = () => {
           event.preventDefault()
           console.log(editor)
         }}
-        className="editor mousetrap"
+        className={`editor mousetrap ${vimState.mode === VimModes.insert ? 'vim-insert-mode' : ''}`}
         value={activeNote.text}
         options={codeMirrorOptions}
         editorDidMount={editor => {
           editor.focus()
           editor.setCursor(0)
+        }}
+        onKeyUp={editor => {
+          if (editor.state.vim) {
+            _updateVimStateMode(editor.state.vim.insertMode ? VimModes.insert : VimModes.default)
+          }
         }}
         onBeforeChange={(editor, data, value) => {
           _updateNote({

--- a/src/slices/settings.ts
+++ b/src/slices/settings.ts
@@ -1,9 +1,12 @@
 import { createSlice, PayloadAction, Slice } from 'redux-starter-kit'
 
-import { SettingsState } from 'types'
+import { SettingsState, VimModes } from 'types'
 
 const initialState: SettingsState = {
   isOpen: false,
+  vimState: {
+    mode: VimModes.default,
+  },
   codeMirrorOptions: {
     mode: 'gfm',
     theme: 'base16-light',
@@ -24,6 +27,12 @@ const settingsSlice: Slice<SettingsState> = createSlice({
       ...state,
       isOpen: !state.isOpen,
     }),
+    updateVimStateMode: (state, { payload }: PayloadAction<VimModes>) => ({
+      ...state,
+      vimState: {
+        mode: payload,
+      },
+    }),
     updateCodeMirrorOption: (
       state,
       { payload }: PayloadAction<{ key: string; value: string }>
@@ -37,6 +46,11 @@ const settingsSlice: Slice<SettingsState> = createSlice({
   },
 })
 
-export const { toggleSettingsModal, updateCodeMirrorOption } = settingsSlice.actions
+export const {
+  toggleSettingsModal,
+  toggleVimInsertMode,
+  updateVimStateMode,
+  updateCodeMirrorOption,
+} = settingsSlice.actions
 
 export default settingsSlice.reducer

--- a/src/styles/_editor.scss
+++ b/src/styles/_editor.scss
@@ -10,6 +10,10 @@
   overflow-y: auto;
 }
 
+.editor.vim-insert-mode {
+  cursor: cell;
+}
+
 .CodeMirror {
   -webkit-font-smoothing: subpixel-antialiased;
   padding: 1rem;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,16 @@ export interface NoteState {
 export interface SettingsState {
   isOpen: boolean
   codeMirrorOptions: { [key: string]: any }
+  vimState: VimState
+}
+
+export enum VimModes {
+  default = '?',
+  insert = 'i',
+}
+
+export interface VimState {
+  mode: VimModes
 }
 
 export interface SyncState {


### PR DESCRIPTION
Because (see #39):

* Is not clear enough when you are on insert mode (Vim)

This commit:

* Is a start of getting the state of Vim

* Create a setting property that includes vim stuff (now, only mode)

* Wants to get some feedback