### PR TITLE
Fix getNoteTitle for non-latin symbols

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -5,7 +5,7 @@ import { Folder } from 'constants/enums'
 import { NoteItem } from 'types'
 
 export const getNoteTitle = (text: string): string => {
-  const noteTitleRegEx = /[\w'?!., ]{1,50}/
+  const noteTitleRegEx = /[\p{Alpha}\p{M}\p{Nd}\p{Pc}\p{Join_C}'?!.,\s]{1,50}/gu
   const noteText = text.match(noteTitleRegEx)
   return noteText ? noteText[0] : 'New Note'
 }


### PR DESCRIPTION
Before:
<img width="505" alt="before" src="https://user-images.githubusercontent.com/201306/67095477-abce1200-f1be-11e9-90a7-d59e593f2275.png">

After:
<img width="505" alt="after" src="https://user-images.githubusercontent.com/201306/67095483-af619900-f1be-11e9-8f7a-83cd4da90d1c.png">
