### PR TITLE
Bug fixed when note list is larger than screen size

### DIFF
--- a/src/containers/NoteList.tsx
+++ b/src/containers/NoteList.tsx
@@ -55,6 +55,22 @@ const NoteList: React.FC = () => {
     event.dataTransfer.setData('text/plain', noteId)
   }
 
+  let [elHeightSiderbar] = useState(0)
+  let [elHeightNoteList] = useState(0)
+  let [elWidthSiderbar] = useState(0)
+  let [isChangeCss] = useState(false)
+
+  const elementNoteSidebar = document.querySelector('.note-sidebar')
+  const elementNoteList = document.querySelector('.note-list')
+
+  if (elementNoteSidebar && elementNoteList) {
+    elHeightSiderbar = elementNoteSidebar.clientHeight
+    elHeightNoteList = elementNoteList.clientHeight
+    elWidthSiderbar = elementNoteSidebar.clientWidth
+
+    isChangeCss = elHeightNoteList >= elHeightSiderbar ? true : false
+  }
+
   useEffect(() => {
     document.addEventListener('mousedown', handleNoteOptionsClick)
     return () => {
@@ -63,8 +79,20 @@ const NoteList: React.FC = () => {
   })
 
   return (
-    <aside className="note-sidebar">
-      <div className="note-sidebar-header">
+    <aside
+      style={{
+        overflowY: isChangeCss ? 'scroll' : 'auto',
+      }}
+      className="note-sidebar"
+    >
+      <div
+        style={{
+          position: isChangeCss ? 'fixed' : 'initial',
+          zIndex: isChangeCss ? 2 : 'initial',
+          width: isChangeCss ? `${elWidthSiderbar}px` : 'auto',
+        }}
+        className="note-sidebar-header"
+      >
         <input
           type="search"
           onChange={event => {
@@ -74,7 +102,12 @@ const NoteList: React.FC = () => {
           placeholder="Search for notes"
         />
       </div>
-      <div className="note-list">
+      <div
+        style={{
+          paddingTop: isChangeCss ? '60px' : '0',
+        }}
+        className="note-list"
+      >
         {filteredNotes.map(note => {
           const noteTitle = getNoteTitle(note.text)
 

--- a/src/styles/_dark.scss
+++ b/src/styles/_dark.scss
@@ -11,6 +11,7 @@ $dark-editor: #3f3f3f;
     border-right: 1px solid darken($dark-sidebar, 8%);
 
     .note-sidebar-header {
+      background: darken($dark-sidebar, 4%);
       color: $light-font-color;
 
       [type='search'] {

--- a/src/styles/_note-sidebar.scss
+++ b/src/styles/_note-sidebar.scss
@@ -3,6 +3,7 @@
   border-right: 1px solid darken($note-sidebar-color, 10%);
 
   &-header {
+    background: $note-sidebar-color;
     padding: 0.5rem;
     text-align: center;
     font-weight: 700;
@@ -61,7 +62,7 @@
           padding: 0.5rem;
           color: $font-color;
           top: 32px;
-          left: 200px;
+          left: 33px;
           min-width: 250px;
           background: white;
           border: 1px solid $accent-gray;


### PR DESCRIPTION
Hello how are you?

I was looking yesterday at the trend topics here and found your project.
Looking at the issues I saw that I could help with something.

I am creating this issue by resolving a at https://github.com/taniarascia/takenote/issues/34.

Some points we can talk about:

Each time the value of the note-list is higher than the note-sidebar I am leaving the input fixed for the user still able to search, with this I leave the note-list with overflow: scroll being able to have the effect of sroll only when it has need.

A possible bug and a new adjustment with this is, by putting overflow: scroll, we will leave the modal options inside this box and like the image below, at the bottom of the list it pushes the box down creating an empty space always at the end of the box. list.

<img width="512" alt="Captura de Tela 2019-10-18 às 16 32 39" src="https://user-images.githubusercontent.com/677288/67123265-2cdcd780-f1c6-11e9-852f-a3a84a4c4852.png">

I already have an idea how to solve this and if I want I can continue working on this feature.

Here is another print of how it looked:

<img width="497" alt="Captura de Tela 2019-10-18 às 16 32 56" src="https://user-images.githubusercontent.com/677288/67123296-49790f80-f1c6-11e9-83a6-7080740d2001.png">

This was applied only to the screen of all notes.

used environment:
OS: Mac
Browser: Chrome v77
No device was emulated from

Hugs