### PR TITLE
fix empty category name

### DIFF
--- a/src/containers/AppSidebar.tsx
+++ b/src/containers/AppSidebar.tsx
@@ -96,7 +96,7 @@ const AppSidebar: React.FC = () => {
 
     const category = { id: uuid(), name: tempCategoryName.trim() }
 
-    if (categories.find(cat => cat.name === tempCategoryName.trim())) {
+    if (categories.find(cat => cat.name === category.name) || category.name === '') {
       resetTempCategory()
     } else {
       _addCategory(category)
@@ -109,7 +109,7 @@ const AppSidebar: React.FC = () => {
 
     const category = { id: editingCategoryId, name: tempCategoryName.trim() }
 
-    if (categories.find(cat => cat.name === tempCategoryName.trim())) {
+    if (categories.find(cat => cat.name === category.name) || category.name === '') {
       resetTempCategory()
     } else {
       _updateCategory(category)


### PR DESCRIPTION
I checked the app by all means and didn't see any example where it's handled `empty category name`.
Now on `add new category` or `update existing category` the category can't be created or will not be updated with an `empty string`. 
Moreover, applying `trim()` twice in the same block, why not use it once.