### PR TITLE
feat(cypress-e2e): add category tests, add cypress-testing-library

### DIFF
--- a/cypress/integration/category.spec.ts
+++ b/cypress/integration/category.spec.ts
@@ -1,0 +1,42 @@
+const addCategory = (categoryName: string) => {
+  cy.findByLabelText('Add category')
+    .should('exist')
+    .click()
+
+  cy.findByPlaceholderText('New category...')
+    .type(`${categoryName}`)
+    .parent()
+    .submit()
+
+  return cy
+    .findByText(categoryName)
+    .should('exist')
+    .click()
+}
+
+describe('Category tests', () => {
+  before(() => {
+    cy.visit('/')
+  })
+
+  it('creates a new category', () => {
+    const categoryName = `Cy${Date.now()}`
+    addCategory(categoryName)
+  })
+
+  it('should delete a category', () => {
+    const categoryName = `Cy${Date.now()}`
+
+    addCategory(categoryName)
+
+    cy.findByText(categoryName)
+      .parent()
+      .within(() => {
+        cy.queryByLabelText('Remove category')
+          .trigger('mouseover')
+          .click()
+      })
+
+    cy.findByText(categoryName).should('not.exist')
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,1 @@
+import '@testing-library/cypress/add-commands'

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -12,3 +12,4 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
+import './commands'

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "include": ["../node_modules/cypress", "*/*.ts"],
   "compilerOptions": {
-    "types": ["cypress"],
+    "types": ["cypress", "@types/testing-library__cypress"],
     "isolatedModules": false,
     "noEmit": false
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,6 +1710,17 @@
         "loader-utils": "^1.2.3"
       }
     },
+    "@testing-library/cypress": {
+      "version": "5.0.2",
+      "resolved": "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-rp-npm-virtual/@testing-library/cypress/-/cypress-5.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40testing-library%2Fcypress%2F-%2Fcypress-5.0.2.tgz",
+      "integrity": "sha1-aHRvydsR2rzEv4g+JbZDFvY3vnE=",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@testing-library/dom": "^6.0.0",
+        "@types/testing-library__cypress": "^5.0.0"
+      }
+    },
     "@testing-library/dom": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.8.1.tgz",
@@ -1929,6 +1940,15 @@
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA=="
     },
+    "@types/jquery": {
+      "version": "3.3.31",
+      "resolved": "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-rp-npm-virtual/@types/jquery/-/jquery-3.3.31.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fjquery%2F-%2Fjquery-3.3.31.tgz",
+      "integrity": "sha1-J8cG5L9IhHThy1SnHYMD83yTRRs=",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
@@ -2030,6 +2050,12 @@
         "@types/react-router": "*"
       }
     },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-rp-npm-virtual/@types/sizzle/-/sizzle-2.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fsizzle%2F-%2Fsizzle-2.3.2.tgz",
+      "integrity": "sha1-qBG4wY4rq6t9VCszZYh64uTZ3kc=",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -2041,6 +2067,16 @@
       "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
       "requires": {
         "@types/estree": "*"
+      }
+    },
+    "@types/testing-library__cypress": {
+      "version": "5.0.0",
+      "resolved": "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-rp-npm-virtual/@types/testing-library__cypress/-/testing-library__cypress-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__cypress%2F-%2Ftesting-library__cypress-5.0.0.tgz",
+      "integrity": "sha1-I1hrYYOlBMWfvXFror0tWpCVKOY=",
+      "dev": true,
+      "requires": {
+        "@types/jquery": "*",
+        "@types/testing-library__dom": "*"
       }
     },
     "@types/testing-library__dom": {
@@ -6559,8 +6595,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6578,13 +6613,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6597,18 +6630,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6711,8 +6741,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6722,7 +6751,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6735,20 +6763,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6765,7 +6790,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -6838,8 +6862,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -6849,7 +6872,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -6925,8 +6947,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -6956,7 +6977,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6974,7 +6994,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7013,13 +7032,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -9120,8 +9137,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9139,13 +9155,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9158,18 +9172,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9272,8 +9283,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9283,7 +9293,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9296,20 +9305,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9326,7 +9332,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9399,8 +9404,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9410,7 +9414,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9486,8 +9489,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9517,7 +9519,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9535,7 +9536,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9574,13 +9574,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -17136,8 +17134,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -17155,13 +17152,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -17174,18 +17169,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -17288,8 +17280,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -17299,7 +17290,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -17312,20 +17302,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -17342,7 +17329,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -17415,8 +17401,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -17426,7 +17411,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -17502,8 +17486,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -17533,7 +17516,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17551,7 +17533,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -17590,13 +17571,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -17887,8 +17866,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -17906,13 +17884,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -17925,18 +17901,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -18039,8 +18012,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -18050,7 +18022,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -18063,20 +18034,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -18093,7 +18061,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -18166,8 +18133,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -18177,7 +18143,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -18253,8 +18218,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -18284,7 +18248,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -18302,7 +18265,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -18341,13 +18303,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "patch-package",
     "start": "react-scripts start",
     "test": "react-scripts test",
-    "e2e": "npx cypress open"
+    "e2e": "cypress open"
   },
   "repository": {
     "type": "git",
@@ -145,6 +145,7 @@
   },
   "devDependencies": {
     "@bahmutov/add-typescript-to-cypress": "^2.1.2",
+    "@testing-library/cypress": "^5.0.2",
     "@testing-library/jest-dom": "^4.1.2",
     "@testing-library/react": "^9.3.0",
     "coveralls": "^3.0.7",

--- a/src/containers/AppSidebar.tsx
+++ b/src/containers/AppSidebar.tsx
@@ -189,11 +189,15 @@ const AppSidebar: React.FC = () => {
 
         <div className="category-title v-between">
           <h2>Categories</h2>
-          <button className="category-button" onClick={newTempCategoryHandler}>
+          <button
+            className="category-button"
+            onClick={newTempCategoryHandler}
+            aria-label="Add category"
+          >
             <Plus size={15} color={iconColor} />
           </button>
         </div>
-        <div className="category-list">
+        <div className="category-list" aria-label="Category list">
           {categories.map(category => {
             return (
               <div
@@ -262,7 +266,7 @@ const AppSidebar: React.FC = () => {
                     _swapNote(newNoteId)
                   }}
                 >
-                  <X size={12} />
+                  <X size={12} aria-label="Remove category" />
                 </div>
               </div>
             )
@@ -271,6 +275,7 @@ const AppSidebar: React.FC = () => {
         {addingTempCategory && (
           <form className="category-form" onSubmit={onSubmitNewCategory}>
             <input
+              aria-label="Category name"
               type="text"
               autoFocus
               maxLength={20}


### PR DESCRIPTION
Related: #107 , #73 

Added e2e tests for:
- add category
- delete category

Other changes:
- added https://github.com/testing-library/cypress-testing-library for cleaner queries and more accessibility aware (adding `data-cy` can clutter the component props a bit, also react-testing-library is used so familiar queries can also be a plus)
- added aria-labels for few elements