### PR TITLE
Fix note-list overflow

### DIFF
--- a/src/containers/NoteList.tsx
+++ b/src/containers/NoteList.tsx
@@ -44,7 +44,7 @@ const NoteList: React.FC = () => {
   const node = useRef<HTMLDivElement>(null)
 
   const handleNoteOptionsClick = (event: ReactMouseEvent, noteId: string = '') => {
-    if (event instanceof MouseEvent) {
+    if (event instanceof MouseEvent && event.target instanceof SVGElement) {
       setNoteOptionsPosition({ x: event.pageX, y: event.pageY })
     }
     event.stopPropagation()

--- a/src/containers/NoteList.tsx
+++ b/src/containers/NoteList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, CSSProperties } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { MoreHorizontal } from 'react-feather'
 import _ from 'lodash'
@@ -44,8 +44,19 @@ const NoteList: React.FC = () => {
   const node = useRef<HTMLDivElement>(null)
 
   const handleNoteOptionsClick = (event: ReactMouseEvent, noteId: string = '') => {
-    if (event instanceof MouseEvent && event.target instanceof SVGElement) {
-      setNoteOptionsPosition({ x: event.pageX, y: event.pageY })
+    if (
+      event instanceof MouseEvent &&
+      (event.target instanceof Element || event.target instanceof SVGElement)
+    ) {
+      console.log('event target:', event, event.target.classList.contains('note-options'))
+      if (event.target.classList.contains('note-options')) {
+        setNoteOptionsPosition({ x: event.pageX, y: event.pageY })
+      }
+      if (event.target.parentElement instanceof Element) {
+        if (event.target.parentElement.classList.contains('note-options')) {
+          setNoteOptionsPosition({ x: event.pageX, y: event.pageY })
+        }
+      }
     }
     event.stopPropagation()
 

--- a/src/containers/NoteList.tsx
+++ b/src/containers/NoteList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState, CSSProperties } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { MoreHorizontal } from 'react-feather'
 import _ from 'lodash'
@@ -57,6 +57,19 @@ const NoteList: React.FC = () => {
     event.stopPropagation()
 
     event.dataTransfer.setData('text/plain', noteId)
+  }
+
+  const getOptionsYPoisition = (): Number => {
+    // get the max window frame
+    const MaxY = window.innerHeight
+
+    // determine approximate options height based on root font-size of 15px, padding, and select box.
+    const optionsSize = 15 * 11
+
+    // if window position - noteOptions position isn't ibgger than options. flip it.
+    return MaxY - noteOptionsPosition.y > optionsSize
+      ? noteOptionsPosition.y
+      : noteOptionsPosition.y - optionsSize
   }
 
   useEffect(() => {
@@ -125,7 +138,7 @@ const NoteList: React.FC = () => {
                   className="note-options-context-menu"
                   style={{
                     position: 'absolute',
-                    top: noteOptionsPosition.y + 'px',
+                    top: getOptionsYPoisition() + 'px',
                     left: noteOptionsPosition.x + 'px',
                   }}
                   onClick={event => {

--- a/src/containers/NoteList.tsx
+++ b/src/containers/NoteList.tsx
@@ -40,9 +40,13 @@ const NoteList: React.FC = () => {
   const _searchNotes = _.debounce((searchValue: string) => dispatch(searchNotes(searchValue)), 200)
 
   const [noteOptionsId, setNoteOptionsId] = useState('')
+  const [noteOptionsPosition, setNoteOptionsPosition] = useState({ x: 0, y: 0 })
   const node = useRef<HTMLDivElement>(null)
 
   const handleNoteOptionsClick = (event: ReactMouseEvent, noteId: string = '') => {
+    if (event instanceof MouseEvent) {
+      setNoteOptionsPosition({ x: event.pageX, y: event.pageY })
+    }
     event.stopPropagation()
 
     if (node.current && node.current.contains(event.target as HTMLDivElement)) return
@@ -119,6 +123,11 @@ const NoteList: React.FC = () => {
                 <div
                   ref={node}
                   className="note-options-context-menu"
+                  style={{
+                    position: 'absolute',
+                    top: noteOptionsPosition.y + 'px',
+                    left: noteOptionsPosition.x + 'px',
+                  }}
                   onClick={event => {
                     event.stopPropagation()
                   }}

--- a/src/styles/_note-sidebar.scss
+++ b/src/styles/_note-sidebar.scss
@@ -2,6 +2,7 @@
   background: $note-sidebar-color;
   border-right: 1px solid darken($note-sidebar-color, 10%);
   overflow-y: hidden;
+  height: 100vh;
 
   &:hover {
     overflow-y: auto;

--- a/src/styles/_note-sidebar.scss
+++ b/src/styles/_note-sidebar.scss
@@ -19,7 +19,6 @@
 
   .note-list {
     &-each {
-      position: relative;
       cursor: pointer;
       padding: 0.25rem 0.5rem;
       border-bottom: 1px solid darken($note-sidebar-color, 8%);

--- a/src/styles/_note-sidebar.scss
+++ b/src/styles/_note-sidebar.scss
@@ -1,6 +1,11 @@
 .note-sidebar {
   background: $note-sidebar-color;
   border-right: 1px solid darken($note-sidebar-color, 10%);
+  overflow-y: hidden;
+
+  &:hover {
+    overflow-y: auto;
+  }
 
   &-header {
     padding: 0.5rem;


### PR DESCRIPTION
Resolves #34 

This PR addresses the issue of the scroll-bar clipping the note options box.
- Sets height of note-list to `100vh`
- Uses absolute positioning to fix clipping
- Avoids bottom bound clipping with rough offset

Can probably be considered a partial fix. This still leaves the note options in place for every note.. There are pieces of that code that depend on having the `note` as context, and I'm still new enough to react/typescript that I couldn't figure out how to fix that. Especially in cases when selecting the `noteOptions` on a `Note` that isn't actively selected. 

Screenshots:
![scroll-bar-hover](https://user-images.githubusercontent.com/926111/67130732-842b7980-f1bf-11e9-9c69-804c6dfcb6a2.png)
![bottom-of-list](https://user-images.githubusercontent.com/926111/67130807-b9d06280-f1bf-11e9-9262-b8f78406e5d4.png)

 