### PR TITLE
fix color for empty-editor in dark mode

### DIFF
--- a/src/styles/_dark.scss
+++ b/src/styles/_dark.scss
@@ -59,6 +59,7 @@ $dark-editor: #3f3f3f;
 
   .empty-editor {
     background: $dark-editor;
+    color: $light-font-color;
   }
 
   .editor .CodeMirror-activeline-background {


### PR DESCRIPTION
`Create a note` was not displaying for empty-editor in dark mode, now it is fixed.