### PR TITLE
Consolidate data ids

### DIFF
--- a/cypress/integration/note.spec.ts
+++ b/cypress/integration/note.spec.ts
@@ -8,7 +8,7 @@ describe('Create note test', () => {
       .children()
       .should('have.length', 0)
 
-    cy.get('[data-cy="Create new note"]').click()
+    cy.get('[data-testid="Create new note"]').click()
 
     cy.get('.note-list')
       .children()
@@ -19,9 +19,9 @@ describe('Create note test', () => {
 
   it('should add a note to favorites', () => {
     cy.get('.note-list-each.active .note-options').click()
-    cy.get('[data-cy="note-option-favorite-button"]').click()
-    cy.get('[data-cy="note-option-favorite-button"]').should('contain', 'Remove Favorite')
-    cy.get('[data-cy="favorites"').click()
+    cy.get('[data-testid="note-option-favorite-button"]').click()
+    cy.get('[data-testid="note-option-favorite-button"]').should('contain', 'Remove favorite')
+    cy.get('[data-testid="favorites"').click()
     cy.get('.note-list')
       .children()
       .should('have.length', 1)
@@ -29,11 +29,11 @@ describe('Create note test', () => {
 
   it('should send a note to trash', () => {
     cy.get('.note-list-each.active .note-options').click()
-    cy.get('[data-cy="note-option-trash-button"]').click()
+    cy.get('[data-testid="note-option-trash-button"]').click()
     cy.get('.note-list')
       .children()
       .should('have.length', 0)
-    cy.get('[data-cy="trash"').click()
+    cy.get('[data-testid="trash"').click()
     cy.get('.note-list')
       .children()
       .should('have.length', 1)
@@ -44,7 +44,7 @@ describe('Create note test', () => {
     cy.get('.note-list')
       .children()
       .should('have.length', 1)
-    cy.get('[data-cy="Empty Trash"]').click()
+    cy.get('[data-testid="Empty Trash"]').click()
     cy.get('.note-list')
       .children()
       .should('have.length', 0)

--- a/src/components/AppSidebarAction.tsx
+++ b/src/components/AppSidebarAction.tsx
@@ -19,7 +19,7 @@ const AppSidebarAction: React.FC<AppSidebarActionProps> = props => {
       onClick={handler}
       disabled={disabled}
       title={label}
-      data-cy={label}
+      data-testid={label}
     >
       <span>
         <IconCmp

--- a/src/components/NoteListButton.test.tsx
+++ b/src/components/NoteListButton.test.tsx
@@ -21,8 +21,8 @@ describe('<NoteListButton />', () => {
       disabled: true,
     }
 
-    const { container } = render(<NoteListButton {...disabledProps} />)
-    const button = container.querySelector('[data-cy="Test"]')
+    const { getByTestId } = render(<NoteListButton {...disabledProps} />)
+    const button = getByTestId('Test')
     expect(button).toHaveAttribute('disabled')
   })
 })

--- a/src/components/NoteListButton.tsx
+++ b/src/components/NoteListButton.tsx
@@ -15,7 +15,7 @@ const NoteListButton: React.FC<NoteListButtonProps> = props => {
       onClick={handler}
       disabled={disabled}
       title={label}
-      data-cy={label}
+      data-testid={label}
     >
       {label}
     </button>

--- a/src/containers/AppSidebar.tsx
+++ b/src/containers/AppSidebar.tsx
@@ -171,7 +171,7 @@ const AppSidebar: React.FC = () => {
           }}
           onDrop={favoriteNoteHandler}
           onDragOver={allowDrop}
-          data-cy="favorites"
+          data-testid="favorites"
         >
           <Star size={15} className="app-sidebar-icon" color={iconColor} />
           Favorites
@@ -183,7 +183,7 @@ const AppSidebar: React.FC = () => {
           }}
           onDrop={trashNoteHandler}
           onDragOver={allowDrop}
-          data-cy="trash"
+          data-testid="trash"
         >
           <Trash2 size={15} className="app-sidebar-icon" color={iconColor} />
           Trash

--- a/src/containers/NoteOptions.tsx
+++ b/src/containers/NoteOptions.tsx
@@ -46,13 +46,13 @@ const NoteOptions: React.FC<NoteOptionsProps> = ({ clickedNote }) => {
       ) : (
         <>
           <NoteOptionsButton
-            data-cy="note-option-favorite-button"
+            data-testid="note-option-favorite-button"
             handler={favoriteNoteHandler}
             icon={Star}
             text={clickedNote.favorite ? 'Remove favorite' : 'Mark as favorite'}
           />
           <NoteOptionsButton
-            data-cy="note-option-trash-button"
+            data-testid="note-option-trash-button"
             handler={trashNoteHandler}
             icon={Trash}
             text="Move to trash"


### PR DESCRIPTION
Makes all the test ids the same and switches the `cy` ones to data-testids for better compatibility with RTL.
Fixes cypress test.