### PR TITLE
Change label of note editor button in preview mode

### DIFF
--- a/src/containers/NoteEditor.tsx
+++ b/src/containers/NoteEditor.tsx
@@ -51,7 +51,7 @@ const NoteEditor: React.FC = () => {
         <>
           <ReactMarkdown className="previewer" source={activeNote.text} />
           <button className="preview-button" onClick={_togglePreviewMarkdown}>
-            Preview
+            Edit
           </button>
         </>
       )


### PR DESCRIPTION
My small contribution :)

**Issue** #174 

## Screenshot

![edit-label](https://user-images.githubusercontent.com/13499566/68358960-d802f180-00df-11ea-9959-352be7db36f1.gif)
