### PR TITLE
Add keyboard shortcut to focus search box

### DIFF
--- a/src/containers/KeyboardShortcuts.tsx
+++ b/src/containers/KeyboardShortcuts.tsx
@@ -69,6 +69,13 @@ const KeyboardShortcuts: React.FC = () => {
     _updateCodeMirrorOption('theme', darkTheme ? 'base16-light' : 'new-moon')
   }
 
+  const focusSearch = () => {
+    const searchBox = document.querySelector<HTMLInputElement>(".note-search")
+    if (searchBox !== null) {
+      searchBox.focus()
+    }
+  }
+
   useKey('ctrl+alt+n', () => {
     if (previewMarkdown) {
       togglePreviewMarkdownHandler()
@@ -98,6 +105,10 @@ const KeyboardShortcuts: React.FC = () => {
 
   useKey('alt+ctrl+k', () => {
     toggleDarkThemeHandler()
+  })
+
+  useKey('alt+ctrl+f', () => {
+    focusSearch()
   })
 
   return null

--- a/src/containers/NoteList.tsx
+++ b/src/containers/NoteList.tsx
@@ -129,6 +129,7 @@ const NoteList: React.FC = () => {
             <Menu />
           </button>
           <input
+            className="note-search"
             type="search"
             onChange={event => {
               event.preventDefault()

--- a/src/containers/SettingsModal.tsx
+++ b/src/containers/SettingsModal.tsx
@@ -162,6 +162,12 @@ const SettingsModal: React.FC = () => {
               <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>K</kbd>
             </div>
           </div>
+          <div className="settings-shortcut">
+            <div>Focus search</div>
+            <div>
+              <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>F</kbd>
+            </div>
+          </div>
         </section>
       </div>
     </div>


### PR DESCRIPTION
I thought it would be nice to quickly jump to the search box with `<ctrl>`+`<alt>`+`<f>` (similar to `<ctrl><f>` in browsers).

I have mixed feelings about my implementation, though. I guess just querying for an element is wrong in a React app. I'm happy to change this if I can get some suggestion what the preferred way would be. I guess it would be adding a flag to the state (`noteState`?), using that in `NoteList`', and dispatching an action on key press?