### PR TITLE
Changes scripts to use `npm ci` instead of `npm i` so `package-lock.j…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - '12'
 install:
-  - 'npm i'
+  - 'npm ci'
 script:
   - npm run coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:12-alpine as builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN ["mkdir","-p","cypress/plugins"]
+RUN npm ci
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
…son` isn't updated every time and we can test on consistent versions.

Also added a line to `Dockerfile` to make the `cypress/plugin` dir since it seems there were issues creating the cypress folder on Docker build