### PR TITLE
Fix category value in the front matter of downloaded notes

### DIFF
--- a/src/client/containers/ContextMenuOptions.tsx
+++ b/src/client/containers/ContextMenuOptions.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { ArrowUp, Download, Star, Trash, X } from 'react-feather'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { ContextMenuOption } from '@/components/NoteList/ContextMenuOption'
 import { downloadNote, getNoteTitle } from '@/helpers'
@@ -12,7 +12,8 @@ import {
   swapCategory,
   swapNote,
 } from '@/slices/note'
-import { NoteItem } from '@/types'
+import { getCategories } from '@/selectors'
+import { CategoryItem, NoteItem } from '@/types'
 
 export interface ContextMenuOptionsProps {
   clickedNote: NoteItem
@@ -29,8 +30,15 @@ export const ContextMenuOptions: React.FC<ContextMenuOptionsProps> = ({ clickedN
   const _swapNote = (noteId: string) => dispatch(swapNote(noteId))
   const _swapCategory = (categoryId: string) => dispatch(swapCategory(categoryId))
 
+  const { categories } = useSelector(getCategories)
+
   const deleteNoteHandler = () => _deleteNote(clickedNote.id)
-  const downloadNoteHandler = () => downloadNote(getNoteTitle(clickedNote.text), clickedNote)
+  const downloadNoteHandler = () =>
+    downloadNote(
+      getNoteTitle(clickedNote.text),
+      clickedNote,
+      categories.find((category: CategoryItem) => category.id === clickedNote.category)
+    )
   const favoriteNoteHandler = () => _toggleFavoriteNote(clickedNote.id)
   const trashNoteHandler = () => _toggleTrashedNote(clickedNote.id)
   const removeCategoryHandler = () => {

--- a/src/client/helpers/index.ts
+++ b/src/client/helpers/index.ts
@@ -17,22 +17,22 @@ export const getNoteTitle = (text: string): string => {
   return noteText ? noteText[0].split(/\r?\n/)[0] : 'New note'
 }
 
-export const noteWithFrontmatter = (note: NoteItem): string =>
+export const noteWithFrontmatter = (note: NoteItem, category?: CategoryItem): string =>
   `---
 title: ${getNoteTitle(note.text)}
 created: ${note.created}
 lastUpdated: ${note.lastUpdated}
-category: ${note.category ? note.category : ''}
+category: ${category?.name ?? ''}
 ---
 
 ${note.text}`
 
-export const downloadNote = (filename: string, note: NoteItem): void => {
+export const downloadNote = (filename: string, note: NoteItem, category?: CategoryItem): void => {
   const pom = document.createElement('a')
 
   pom.setAttribute(
     'href',
-    `data:text/plain;charset=utf-8,${encodeURIComponent(noteWithFrontmatter(note))}`
+    `data:text/plain;charset=utf-8,${encodeURIComponent(noteWithFrontmatter(note, category))}`
   )
   pom.setAttribute('download', `${filename}.md`)
 

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -12,6 +12,9 @@ export interface NoteItem {
   text: string
   created: string
   lastUpdated: string
+  /**
+   * Refers to the category UUID and not the actual name.
+   */
   category?: string
   trash?: boolean
   favorite?: boolean


### PR DESCRIPTION
Hello,

These changes attempt to address #249.

As I noted in my commit message, it'd seem ideal in the long-term to rename the `category` property in `NoteItem` to `categoryId` to avoid confusion of the actual value of the property. However, I noticed that this will probably break existing category linkages to notes because it looks to be a schema change.

Open for adjustments.