### PR TITLE
Confirm exit

### DIFF
--- a/cypress/integration/note.spec.ts
+++ b/cypress/integration/note.spec.ts
@@ -190,6 +190,10 @@ describe('Manage notes test', () => {
     const noteThreeTitle = 'same note title'
     const noteFourTitle = 'note 4'
 
+    Cypress.on('window:before:unload', (event: BeforeUnloadEvent) =>
+      expect(event.returnValue).to.equal('')
+    )
+
     // start with a refresh so we know our current saved state
     cy.reload()
     getNoteCount('allNoteStartCount')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -13,3 +13,21 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 import './commands'
+
+// Since before unload alert hangs console tests, the alert has to be disabled
+// Check https://github.com/cypress-io/cypress/issues/2118 for more info
+Cypress.on('window:before:load', function(win) {
+  const original = win.EventTarget.prototype.addEventListener
+
+  win.EventTarget.prototype.addEventListener = function() {
+    if (arguments && arguments[0] === 'beforeunload') {
+      return
+    }
+    return original.apply(this, arguments)
+  }
+
+  Object.defineProperty(win, 'onbeforeunload', {
+    get: function() {},
+    set: function() {},
+  })
+})

--- a/src/client/containers/NoteEditor.tsx
+++ b/src/client/containers/NoteEditor.tsx
@@ -14,6 +14,7 @@ import 'codemirror/lib/codemirror.css'
 import 'codemirror/theme/base16-light.css'
 import 'codemirror/mode/gfm/gfm'
 import 'codemirror/addon/selection/active-line'
+import { setPendingSync } from '@/slices/sync'
 
 export const NoteEditor: React.FC = () => {
   const { activeNoteId, loading, notes } = useSelector(getNotes)
@@ -21,7 +22,10 @@ export const NoteEditor: React.FC = () => {
 
   const dispatch = useDispatch()
   const _togglePreviewMarkdown = () => dispatch(togglePreviewMarkdown())
-  const _updateNote = (note: NoteItem) => dispatch(updateNote(note))
+  const _updateNote = (note: NoteItem) => {
+    dispatch(setPendingSync())
+    dispatch(updateNote(note))
+  }
 
   const activeNote = notes.find(note => note.id === activeNoteId)
 

--- a/src/client/containers/TakeNoteApp.tsx
+++ b/src/client/containers/TakeNoteApp.tsx
@@ -8,7 +8,7 @@ import { NoteEditor } from '@/containers/NoteEditor'
 import { NoteList } from '@/containers/NoteList'
 import { SettingsModal } from '@/containers/SettingsModal'
 import { TempStateProvider } from '@/contexts/TempStateContext'
-import { useInterval } from '@/helpers/hooks'
+import { useInterval, useBeforeUnload } from '@/helpers/hooks'
 import { getWebsiteTitle, determineTheme } from '@/helpers'
 import { loadCategories } from '@/slices/category'
 import { loadNotes } from '@/slices/note'
@@ -21,6 +21,8 @@ export const TakeNoteApp: React.FC = () => {
   const { darkTheme } = useSelector(getSettings)
   const { activeFolder, activeCategoryId, notes } = useSelector(getNotes)
   const { categories } = useSelector(getCategories)
+  const { pendingSync } = useSelector(getSync)
+  useBeforeUnload((event: BeforeUnloadEvent) => (pendingSync ? event.preventDefault() : null))
 
   const dispatch = useDispatch()
   const _loadNotes = () => dispatch(loadNotes())

--- a/src/client/slices/sync.ts
+++ b/src/client/slices/sync.ts
@@ -6,12 +6,17 @@ const initialState: SyncState = {
   error: '',
   syncing: false,
   lastSynced: '',
+  pendingSync: false,
 }
 
 const syncSlice = createSlice({
   name: 'sync',
   initialState,
   reducers: {
+    setPendingSync: state => ({
+      ...state,
+      pendingSync: true,
+    }),
     syncState: (state, { payload }: PayloadAction<SyncStatePayload>) => ({
       ...state,
       syncing: true,
@@ -25,10 +30,11 @@ const syncSlice = createSlice({
       ...state,
       lastSynced: payload,
       syncing: false,
+      pendingSync: false,
     }),
   },
 })
 
-export const { syncState, syncStateError, syncStateSuccess } = syncSlice.actions
+export const { syncState, syncStateError, syncStateSuccess, setPendingSync } = syncSlice.actions
 
 export default syncSlice.reducer

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -62,6 +62,7 @@ export interface SyncState {
   syncing: boolean
   lastSynced: string
   error: string
+  pendingSync: boolean
 }
 
 export interface RootState {


### PR DESCRIPTION
Issue #78 

## Changes

- Added `useBeforeUnload` hook
- Confirm exit dialog
- Modified Sync slice to have pendingSync property

## Potential feature
After merge, a loading sync icon could be added to notify the user when his notes are synced. 

## Considerations
Since there is a reload bug on the before unload alert, a workaround was used to fix Cypress sync test to handle this. However, a future release may fix it.

This [Cypress repository issue](https://github.com/cypress-io/cypress/issues/2118) tracks the fix of the bug.