### PR TITLE
Fix typos across takenote repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,6 @@ Coding conventions are enforced by [ESLint](.eslintrc.js) and [Prettier](.pretti
 - Trailing commas in arrays and objects
 - [Non-default exports](https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/) are preferred for components
 - Module imports are ordered and separated: **built-in** -> **external** -> **internal** -> **css/assets/other**
-- TypeScript: strict mode, with no implicity any
+- TypeScript: strict mode, with no implicitly any
 - React: functional style with Hooks (no classes)
 - `const` preferred over `let`

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -49,7 +49,7 @@ module.exports = {
        * TypeScript (.ts/.tsx files)
        *
        * The TypeScript loader will compile all .ts/.tsx files to .js. Babel is
-       * not necessarry here since TypeScript is taking care of all transpiling.
+       * not necessary here since TypeScript is taking care of all transpiling.
        */
       {
         test: /\.ts(x?)$/,

--- a/src/server/handlers/auth.ts
+++ b/src/server/handlers/auth.ts
@@ -21,7 +21,7 @@ export default {
    * 2. The code will be exchanged for an access token on the `/access_token`
    * endpoint and the user will be redirected to the app.
    *
-   * Client-side persistance
+   * Client-side persistence
    * @url https://www.taniarascia.com/full-stack-cookies-localstorage-react-express/
    *
    * A thirty day, secure, HTTP only, and same-site cookie will be set on the app

--- a/tests/e2e/utils/testHelperUtils.ts
+++ b/tests/e2e/utils/testHelperUtils.ts
@@ -21,7 +21,7 @@ const defaultInit = () => {
     cy.visit(entryPoint)
 
     // wait for things to settle .. like waiting for Welcome Note to resolve
-    // increasing due to occassional flaky starts
+    // increasing due to occasional flaky starts
     cy.wait(200)
   })
 }


### PR DESCRIPTION
:writing_hand: **Fix typos across takenote repo**

**Files that have typos**

```
takenote/CONTRIBUTING.md:115:35: "implicity" is a misspelling of "implicitly"
takenote/config/webpack.common.js:52:13: "necessarry" is a misspelling of "necessary"
takenote/src/server/handlers/auth.ts:24:17: "persistance" is a misspelling of "persistence"
takenote/tests/e2e/utils/testHelperUtils.ts:24:25: "occassional" is a misspelling of "occasional"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: 

Making the world a better place :innocent: