### PR TITLE
Trash to all notes

### DIFF
--- a/src/client/components/AppSidebar/AllNotesOption.tsx
+++ b/src/client/components/AppSidebar/AllNotesOption.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Book } from 'react-feather'
 
 import { LabelText } from '@resources/LabelText'

--- a/src/client/components/AppSidebar/AllNotesOption.tsx
+++ b/src/client/components/AppSidebar/AllNotesOption.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Book } from 'react-feather'
 
 import { LabelText } from '@resources/LabelText'
@@ -10,24 +10,44 @@ import { ReactDragEvent } from '@/types'
 
 export interface AllNotesOptionProps {
   active: boolean
+  folder: Folder
   swapFolder: (folder: Folder) => {}
   addNoteType: (noteId: string) => void
 }
 
 export const AllNotesOption: React.FC<AllNotesOptionProps> = ({
   active,
+  folder,
   swapFolder,
   addNoteType,
 }) => {
+  const [isDraggedOver, setIsDraggedOver] = useState(false)
+  const dragEnterHandler = () => {
+    if (folder === Folder.ALL) {
+      setIsDraggedOver(true)
+    }
+  }
+  const dragLeaveHandler = () => {
+    setIsDraggedOver(false)
+  }
   const noteHandler = (event: ReactDragEvent) => {
     event.preventDefault()
     addNoteType(event.dataTransfer.getData('text'))
+  }
+  const determineClass = () => {
+    if (active) {
+      return 'app-sidebar-link active'
+    } else if (isDraggedOver) {
+      return 'app-sidebar-link dragged-over'
+    } else {
+      return 'app-sidebar-link'
+    }
   }
 
   return (
     <div
       data-testid={TestID.FOLDER_NOTES}
-      className={`app-sidebar-link ${active ? 'active' : ''}`}
+      className={determineClass()}
       onClick={() => {
         swapFolder(Folder.ALL)
       }}
@@ -35,6 +55,8 @@ export const AllNotesOption: React.FC<AllNotesOptionProps> = ({
         event.preventDefault()
       }}
       onDrop={noteHandler}
+      onDragEnter={dragEnterHandler}
+      onDragLeave={dragLeaveHandler}
     >
       <Book size={15} className="app-sidebar-icon" color={iconColor} />
       {LabelText.NOTES}

--- a/src/client/components/AppSidebar/AllNotesOption.tsx
+++ b/src/client/components/AppSidebar/AllNotesOption.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Book } from 'react-feather'
 
 import { LabelText } from '@resources/LabelText'
@@ -11,17 +11,22 @@ import { ReactDragEvent } from '@/types'
 export interface AllNotesOptionProps {
   active: boolean
   swapFolder: (folder: Folder) => {}
-  noteHandler: (event: ReactDragEvent) => void
+  addNoteType: (noteId: string) => void
 }
 
 export const AllNotesOption: React.FC<AllNotesOptionProps> = ({
   active,
   swapFolder,
-  noteHandler,
+  addNoteType,
 }) => {
+  const noteHandler = (event: ReactDragEvent) => {
+    event.preventDefault()
+    addNoteType(event.dataTransfer.getData('text'))
+  }
+
   return (
     <div
-      data-testid={TestID.FOLDER_ALL_NOTES}
+      data-testid={TestID.FOLDER_NOTES}
       className={`app-sidebar-link ${active ? 'active' : ''}`}
       onClick={() => {
         swapFolder(Folder.ALL)
@@ -32,7 +37,7 @@ export const AllNotesOption: React.FC<AllNotesOptionProps> = ({
       onDrop={noteHandler}
     >
       <Book size={15} className="app-sidebar-icon" color={iconColor} />
-      {LabelText.ALL_NOTES}
+      {LabelText.NOTES}
     </div>
   )
 }

--- a/src/client/components/AppSidebar/AllNotesOption.tsx
+++ b/src/client/components/AppSidebar/AllNotesOption.tsx
@@ -6,13 +6,19 @@ import { TestID } from '@resources/TestID'
 
 import { Folder } from '@/utils/enums'
 import { iconColor } from '@/utils/constants'
+import { ReactDragEvent } from '@/types'
 
 export interface AllNotesOptionProps {
   active: boolean
   swapFolder: (folder: Folder) => {}
+  noteHandler: (event: ReactDragEvent) => void
 }
 
-export const AllNotesOption: React.FC<AllNotesOptionProps> = ({ active, swapFolder }) => {
+export const AllNotesOption: React.FC<AllNotesOptionProps> = ({
+  active,
+  swapFolder,
+  noteHandler,
+}) => {
   return (
     <div
       data-testid={TestID.FOLDER_ALL_NOTES}
@@ -20,6 +26,10 @@ export const AllNotesOption: React.FC<AllNotesOptionProps> = ({ active, swapFold
       onClick={() => {
         swapFolder(Folder.ALL)
       }}
+      onDragOver={(event: ReactDragEvent) => {
+        event.preventDefault()
+      }}
+      onDrop={noteHandler}
     >
       <Book size={15} className="app-sidebar-icon" color={iconColor} />
       {LabelText.ALL_NOTES}

--- a/src/client/components/AppSidebar/AllNotesOption.tsx
+++ b/src/client/components/AppSidebar/AllNotesOption.tsx
@@ -32,7 +32,9 @@ export const AllNotesOption: React.FC<AllNotesOptionProps> = ({
   }
   const noteHandler = (event: ReactDragEvent) => {
     event.preventDefault()
+
     addNoteType(event.dataTransfer.getData('text'))
+    dragLeaveHandler()
   }
   const determineClass = () => {
     if (active) {
@@ -51,10 +53,10 @@ export const AllNotesOption: React.FC<AllNotesOptionProps> = ({
       onClick={() => {
         swapFolder(Folder.ALL)
       }}
+      onDrop={noteHandler}
       onDragOver={(event: ReactDragEvent) => {
         event.preventDefault()
       }}
-      onDrop={noteHandler}
       onDragEnter={dragEnterHandler}
       onDragLeave={dragLeaveHandler}
     >

--- a/src/client/components/AppSidebar/FolderOption.tsx
+++ b/src/client/components/AppSidebar/FolderOption.tsx
@@ -38,6 +38,8 @@ export const FolderOption: React.FC<FolderOptionProps> = ({
   const noteHandler = (event: ReactDragEvent) => {
     event.preventDefault()
 
+    console.log(folder)
+
     addNoteType(event.dataTransfer.getData('text'))
     dragLeaveHandler()
   }

--- a/src/client/components/AppSidebar/FolderOption.tsx
+++ b/src/client/components/AppSidebar/FolderOption.tsx
@@ -38,8 +38,6 @@ export const FolderOption: React.FC<FolderOptionProps> = ({
   const noteHandler = (event: ReactDragEvent) => {
     event.preventDefault()
 
-    console.log(folder)
-
     addNoteType(event.dataTransfer.getData('text'))
     dragLeaveHandler()
   }

--- a/src/client/containers/AppSidebar.tsx
+++ b/src/client/containers/AppSidebar.tsx
@@ -230,6 +230,7 @@ export const AppSidebar: React.FC = () => {
           <ScratchpadOption active={activeFolder === Folder.SCRATCHPAD} swapFolder={_swapFolder} />
           <AllNotesOption
             active={activeFolder === Folder.ALL}
+            folder={Folder.ALL}
             swapFolder={_swapFolder}
             addNoteType={_addAllNote}
           />

--- a/src/client/containers/AppSidebar.tsx
+++ b/src/client/containers/AppSidebar.tsx
@@ -228,8 +228,16 @@ export const AppSidebar: React.FC = () => {
         </section>
         <section className="app-sidebar-main">
           <ScratchpadOption active={activeFolder === Folder.SCRATCHPAD} swapFolder={_swapFolder} />
-          <AllNotesOption
+          {/* <AllNotesOption
             active={activeFolder === Folder.ALL}
+            folder={Folder.ALL}
+            swapFolder={_swapFolder}
+            addNoteType={_addAllNote}
+          /> */}
+          <FolderOption
+            active={activeFolder === Folder.ALL}
+            text={LabelText.NOTES}
+            dataTestID={TestID.FOLDER_NOTES}
             folder={Folder.ALL}
             swapFolder={_swapFolder}
             addNoteType={_addAllNote}

--- a/src/client/containers/AppSidebar.tsx
+++ b/src/client/containers/AppSidebar.tsx
@@ -226,7 +226,11 @@ export const AppSidebar: React.FC = () => {
         </section>
         <section className="app-sidebar-main">
           <ScratchpadOption active={activeFolder === Folder.SCRATCHPAD} swapFolder={_swapFolder} />
-          <AllNotesOption active={activeFolder === Folder.ALL} swapFolder={_swapFolder} />
+          <AllNotesOption
+            active={activeFolder === Folder.ALL}
+            swapFolder={_swapFolder}
+            noteHandler={(e: ReactDragEvent) => console.log(e)}
+          />
           <FolderOption
             active={activeFolder === Folder.FAVORITES}
             text={LabelText.FAVORITES}

--- a/src/client/containers/AppSidebar.tsx
+++ b/src/client/containers/AppSidebar.tsx
@@ -40,6 +40,7 @@ import {
   swapNote,
   addFavoriteNote,
   addTrashedNote,
+  addAllNote,
 } from '@/slices/note'
 import { toggleSettingsModal, togglePreviewMarkdown } from '@/slices/settings'
 import { syncState } from '@/slices/sync'
@@ -85,6 +86,7 @@ export const AppSidebar: React.FC = () => {
     dispatch(syncState({ notes, categories }))
   const _toggleSettingsModal = () => dispatch(toggleSettingsModal())
   const _togglePreviewMarkdown = () => dispatch(togglePreviewMarkdown())
+  const _addAllNote = (noteId: string) => dispatch(addAllNote(noteId))
   const _addTrashedNote = (noteId: string) => dispatch(addTrashedNote(noteId))
   const _addFavoriteNote = (noteId: string) => dispatch(addFavoriteNote(noteId))
   const _addCategoryToNote = (categoryId: string, noteId: string) =>
@@ -229,7 +231,7 @@ export const AppSidebar: React.FC = () => {
           <AllNotesOption
             active={activeFolder === Folder.ALL}
             swapFolder={_swapFolder}
-            noteHandler={(e: ReactDragEvent) => console.log(e)}
+            addNoteType={_addAllNote}
           />
           <FolderOption
             active={activeFolder === Folder.FAVORITES}

--- a/src/client/slices/note.ts
+++ b/src/client/slices/note.ts
@@ -138,6 +138,10 @@ const noteSlice = createSlice({
         state.activeFolder
       ),
     }),
+    addAllNote: (state, { payload }: PayloadAction<string>) => ({
+      ...state,
+      notes: state.notes.map(note => (note.id === payload ? { ...note, trash: false } : note)),
+    }),
     addFavoriteNote: (state, { payload }: PayloadAction<string>) => ({
       ...state,
       notes: state.notes.map(note => (note.id === payload ? { ...note, favorite: true } : note)),
@@ -179,6 +183,7 @@ export const {
   swapNote,
   toggleFavoriteNote,
   toggleTrashedNote,
+  addAllNote,
   addFavoriteNote,
   addTrashedNote,
   updateNote,

--- a/src/resources/LabelText.ts
+++ b/src/resources/LabelText.ts
@@ -1,7 +1,7 @@
 // Default Labels
 export enum LabelText {
   ADD_CATEGORY = 'Add Category',
-  ALL_NOTES = 'All Notes',
+  NOTES = 'Notes',
   CREATE_NEW_NOTE = 'Create new note',
   DELETE_PERMANENTLY = 'Delete permanently',
   DOWNLOAD = 'Download',

--- a/src/resources/TestID.ts
+++ b/src/resources/TestID.ts
@@ -8,7 +8,7 @@ export enum TestID {
   CATEGORY_OPTION_DELETE_PERMANENTLY = 'category-option-delete-permanently',
   EDIT_CATEGORY = 'edit-category',
   EMPTY_TRASH_BUTTON = 'empty-trash-button',
-  FOLDER_ALL_NOTES = 'all-notes',
+  FOLDER_NOTES = 'notes',
   FOLDER_FAVORITES = 'favorites',
   FOLDER_TRASH = 'trash',
   NEW_CATEGORY_FORM = 'new-category-form',

--- a/tests/e2e/utils/testHelperUtils.ts
+++ b/tests/e2e/utils/testHelperUtils.ts
@@ -45,7 +45,7 @@ const getNoteCount = (noteCountAlias: string) => {
 }
 
 const navigateToAllNotes = () => {
-  clickTestID(TestID.FOLDER_ALL_NOTES)
+  clickTestID(TestID.FOLDER_NOTES)
 }
 
 const navigateToFavorites = () => {


### PR DESCRIPTION
## [Feature] Unable to drag note from 'Trash' to 'All notes' #289

Rename 'All Notes' folder in sidebar to 'Notes' & make add the ability to restore a trashed note to Notes with Drag & Drop.

Fixes #

## Browser Checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Questions about implementation

- Should i make the 'Notes' folder use the FolderOption component and delete the AllNotesOption component?
- When a user drags a note from the favorites section, should the note marked as not a favorite or there should not be such option?