### PR TITLE
refactor: remove lodash, create debounceEvent helper, regex escape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12348,7 +12348,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "helmet": "^3.21.2",
-    "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "mousetrap": "^1.6.3",
     "mousetrap-global-bind": "^1.1.0",

--- a/src/client/containers/NoteList.tsx
+++ b/src/client/containers/NoteList.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { MoreHorizontal, Star, Menu } from 'react-feather'
-import _ from 'lodash'
 
 import { TestID } from '@resources/TestID'
 
@@ -14,6 +13,7 @@ import {
   sortByLastUpdated,
   sortByFavorites,
   shouldOpenContextMenu,
+  debounceEvent,
 } from '@/utils/helpers'
 import { useKey } from '@/utils/hooks'
 import { emptyTrash, pruneNotes, swapNote, searchNotes } from '@/slices/note'
@@ -38,7 +38,10 @@ export const NoteList: React.FC = () => {
   const _toggleSidebarVisibility = () => dispatch(toggleSidebarVisibility())
   const _pruneNotes = () => dispatch(pruneNotes())
   const _swapNote = (noteId: string) => dispatch(swapNote(noteId))
-  const _searchNotes = _.debounce((searchValue: string) => dispatch(searchNotes(searchValue)), 100)
+  const _searchNotes = debounceEvent(
+    (searchValue: string) => dispatch(searchNotes(searchValue)),
+    100
+  )
 
   // ===========================================================================
   // Refs
@@ -54,7 +57,7 @@ export const NoteList: React.FC = () => {
   const [optionsId, setOptionsId] = useState('')
   const [optionsPosition, setOptionsPosition] = useState({ x: 0, y: 0 })
 
-  const re = new RegExp(_.escapeRegExp(searchValue), 'i')
+  const re = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
   const isMatch = (result: NoteItem) => re.test(result.text)
 
   const filter: Record<Folder, (note: NoteItem) => boolean> = {

--- a/src/client/utils/helpers.ts
+++ b/src/client/utils/helpers.ts
@@ -167,3 +167,12 @@ export const determineCategoryClass = (
     return 'category-list-each'
   }
 }
+
+export const debounceEvent = <T extends Function>(cb: T, wait = 20) => {
+  let h = 0
+  let callable = (...args: any) => {
+    clearTimeout(h)
+    h = window.setTimeout(() => cb(...args), wait)
+  }
+  return <T>(<any>callable)
+}


### PR DESCRIPTION
Please read the [Contribution Guidelines](../CONTRIBUTING.md) before opening a pull request.

## Description

Removes lodash package and replaces with native helpers.
[debounce.ts](https://gist.github.com/ca0v/73a31f57b397606c9813472f7493a940)
[Escape string for use in Javascript regex](https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex)

Fixes #272 

## Browser Checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
