### PR TITLE
Fix legacy settings

### DIFF
--- a/src/client/slices/settings.ts
+++ b/src/client/slices/settings.ts
@@ -64,10 +64,11 @@ const settingsSlice = createSlice({
       ...state,
       loading: false,
     }),
-    loadSettingsSuccess: (_, { payload }: PayloadAction<SettingsState>) => ({
+    loadSettingsSuccess: (state, { payload }: PayloadAction<SettingsState>) => ({
       ...payload,
       isOpen: false,
       loading: false,
+      notesSortKey: !state.notesSortKey ? NotesSortKey.LAST_UPDATED : state.notesSortKey,
     }),
   },
 })


### PR DESCRIPTION
The note sorter added a field to settings. Any existing accounts would not have this setting and therefore it would break. This will ensure it gets added to state even if nothing exists.