### PR TITLE
Add note to folder triggers the action for the note and not the selected ones

### DIFF
--- a/src/client/slices/note.ts
+++ b/src/client/slices/note.ts
@@ -164,15 +164,29 @@ const noteSlice = createSlice({
     }),
     addFavoriteNote: (state, { payload }: PayloadAction<string>) => ({
       ...state,
-      notes: state.notes.map(note =>
-        state.selectedNotesIds.includes(note.id) ? { ...note, favorite: true } : note
-      ),
+      notes: state.notes.map(note => {
+        if (state.selectedNotesIds.includes(payload)) {
+          return state.selectedNotesIds.includes(note.id) ? { ...note, favorite: true } : note
+        }
+        if (note.id === payload) {
+          return { ...note, favorite: true }
+        }
+
+        return note
+      }),
     }),
     addTrashedNote: (state, { payload }: PayloadAction<string>) => ({
       ...state,
-      notes: state.notes.map(note =>
-        state.selectedNotesIds.includes(note.id) ? { ...note, trash: true } : note
-      ),
+      notes: state.notes.map(note => {
+        if (state.selectedNotesIds.includes(payload)) {
+          return state.selectedNotesIds.includes(note.id) ? { ...note, trash: true } : note
+        }
+        if (note.id === payload) {
+          return { ...note, trash: true }
+        }
+
+        return note
+      }),
       activeNoteId: getNewActiveNoteId(
         state.notes,
         payload,


### PR DESCRIPTION
## [Bug] Dropping a not selected note into a folder, triggers actions for the selected note #320
## Description

Dropping a note to a folder should only add that note in the folder if it isn't selected, else all selected  notes are added to the folder.

## Browser Checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari
