### PR TITLE
Fix firefox flex bug #322

### DIFF
--- a/src/client/styles/_note-sidebar.scss
+++ b/src/client/styles/_note-sidebar.scss
@@ -22,6 +22,7 @@
     input {
       -webkit-appearance: none;
       margin: 0;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
Please read the [Contribution Guidelines](../CONTRIBUTING.md) before opening a pull request.

## Description
Flex shrink behaviour differs between FF and Chromium, which caused an input to be too wide on FF. Adding min-width allows the flex-shrink to work as intended.

Fixes #322 
## Browser Checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari
