### PR TITLE
Fixed LandingPage footer spacing

### DIFF
--- a/src/client/styles/_landing-page.scss
+++ b/src/client/styles/_landing-page.scss
@@ -189,6 +189,7 @@
 
     a {
       color: rgba(255, 255, 255, 0.8);
+      min-width: 100px;
       &:hover {
         color: white;
       }


### PR DESCRIPTION
Please read the [Contribution Guidelines](../CONTRIBUTING.md) before opening a pull request.

## Description

The landing page footer had 3 links that was off center from the rest of the footer content. The change I made to fix this was adding a 100px min-width to the footers 'a' tags to create a even spacing.

## Before 

<img width="338" alt="Screenshot 2020-05-07 at 10 41 49" src="https://user-images.githubusercontent.com/50870173/81273615-6d5f4e00-904f-11ea-9691-d60470ddcfec.png">

## After 

<img width="338" alt="Screenshot 2020-05-07 at 10 41 15" src="https://user-images.githubusercontent.com/50870173/81273608-6afcf400-904f-11ea-93b4-e1fcb1db1518.png">



Fixes #

Footer on the landing page

## Browser Checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari


