### PR TITLE
Add persist sort keys on tab change.

### DIFF
--- a/src/client/slices/settings.ts
+++ b/src/client/slices/settings.ts
@@ -27,7 +27,7 @@ const settingsSlice = createSlice({
   name: 'settings',
   initialState,
   reducers: {
-    toggleSettingsModal: state => ({
+    toggleSettingsModal: (state) => ({
       ...state,
       isOpen: !state.isOpen,
     }),
@@ -41,15 +41,15 @@ const settingsSlice = createSlice({
         [payload.key]: payload.value,
       },
     }),
-    togglePreviewMarkdown: state => ({
+    togglePreviewMarkdown: (state) => ({
       ...state,
       previewMarkdown: !state.previewMarkdown,
     }),
-    toggleDarkTheme: state => ({
+    toggleDarkTheme: (state) => ({
       ...state,
       darkTheme: !state.darkTheme,
     }),
-    toggleSidebarVisibility: state => ({
+    toggleSidebarVisibility: (state) => ({
       ...state,
       sidebarVisible: !state.sidebarVisible,
     }),
@@ -57,11 +57,11 @@ const settingsSlice = createSlice({
       ...state,
       notesSortKey: payload,
     }),
-    loadSettings: state => ({
+    loadSettings: (state) => ({
       ...state,
       loading: true,
     }),
-    loadSettingsError: state => ({
+    loadSettingsError: (state) => ({
       ...state,
       loading: false,
     }),
@@ -69,7 +69,6 @@ const settingsSlice = createSlice({
       ...payload,
       isOpen: false,
       loading: false,
-      notesSortKey: !state.notesSortKey ? NotesSortKey.LAST_UPDATED : state.notesSortKey,
     }),
   },
 })


### PR DESCRIPTION
Please read the [Contribution Guidelines](../CONTRIBUTING.md) before opening a pull request.

## Description

Settings persistence was working fine, except sorting. When we open new tab, initial state defaults to "last updated" and doesn't change to the one from previous tab.

Fixes #344 

## Browser Checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari
