### PR TITLE
Bug fix for #355

### DIFF
--- a/src/client/containers/AppSidebar.tsx
+++ b/src/client/containers/AppSidebar.tsx
@@ -17,8 +17,8 @@ import {
   updateActiveNote,
   addFavoriteNote,
   addTrashedNote,
-  toggleTrashedNote,
   updateSelectedNotes,
+  restoreTrashedNote,
 } from '@/slices/note'
 import { toggleSettingsModal, togglePreviewMarkdown } from '@/slices/settings'
 import { syncState } from '@/slices/sync'
@@ -55,7 +55,7 @@ export const AppSidebar: React.FC = () => {
   const _toggleSettingsModal = () => dispatch(toggleSettingsModal())
   const _togglePreviewMarkdown = () => dispatch(togglePreviewMarkdown())
   const _addTrashedNote = (noteId: string) => dispatch(addTrashedNote(noteId))
-  const _toggleTrashedNote = (noteId: string) => dispatch(toggleTrashedNote(noteId))
+  const _restoreTrashedNote = (noteId: string) => dispatch(restoreTrashedNote(noteId))
   const _addFavoriteNote = (noteId: string) => dispatch(addFavoriteNote(noteId))
 
   // ===========================================================================
@@ -109,7 +109,7 @@ export const AppSidebar: React.FC = () => {
             text={LabelText.NOTES}
             dataTestID={TestID.FOLDER_NOTES}
             folder={Folder.ALL}
-            addNoteType={_toggleTrashedNote}
+            addNoteType={_restoreTrashedNote}
           />
           <FolderOption
             active={activeFolder === Folder.FAVORITES}

--- a/src/client/slices/note.ts
+++ b/src/client/slices/note.ts
@@ -10,10 +10,10 @@ const getNewActiveNoteId = (
   activeFolder: Folder
 ): string => {
   const newActiveNotes = notes
-    .filter(note => !note.scratchpad) // filter out all scratchpad notes
-    .filter(note => (activeFolder !== Folder.TRASH ? !note.trash : note.trash)) // trash or not trash
-    .filter(note => (activeCategoryId ? note.category === activeCategoryId : true)) // filter category if necessary
-  const trashedNoteIndex = newActiveNotes.findIndex(note => note.id === oldNoteId)
+    .filter((note) => !note.scratchpad) // filter out all scratchpad notes
+    .filter((note) => (activeFolder !== Folder.TRASH ? !note.trash : note.trash)) // trash or not trash
+    .filter((note) => (activeCategoryId ? note.category === activeCategoryId : true)) // filter category if necessary
+  const trashedNoteIndex = newActiveNotes.findIndex((note) => note.id === oldNoteId)
 
   if (trashedNoteIndex === 0 && newActiveNotes[1]) return newActiveNotes[1].id
   if (newActiveNotes[trashedNoteIndex - 1]) return newActiveNotes[trashedNoteIndex - 1].id
@@ -22,13 +22,13 @@ const getNewActiveNoteId = (
 }
 
 export const getFirstNoteId = (folder: Folder, notes: NoteItem[], categoryId?: string): string => {
-  const notesNotTrash = notes.filter(note => !note.trash)
+  const notesNotTrash = notes.filter((note) => !note.trash)
   const firstNote = {
-    [Folder.ALL]: () => notesNotTrash.find(note => !note.scratchpad),
-    [Folder.CATEGORY]: () => notesNotTrash.find(note => note.category === categoryId),
-    [Folder.FAVORITES]: () => notesNotTrash.find(note => note.favorite),
-    [Folder.SCRATCHPAD]: () => notesNotTrash.find(note => note.scratchpad),
-    [Folder.TRASH]: () => notes.find(note => note.trash),
+    [Folder.ALL]: () => notesNotTrash.find((note) => !note.scratchpad),
+    [Folder.CATEGORY]: () => notesNotTrash.find((note) => note.category === categoryId),
+    [Folder.FAVORITES]: () => notesNotTrash.find((note) => note.favorite),
+    [Folder.SCRATCHPAD]: () => notesNotTrash.find((note) => note.scratchpad),
+    [Folder.TRASH]: () => notes.find((note) => note.trash),
   }[folder]()
   return firstNote ? firstNote.id : ''
 }
@@ -54,12 +54,12 @@ const noteSlice = createSlice({
     ) => ({
       ...state,
       notes: state.selectedNotesIds.includes(payload.noteId)
-        ? state.notes.map(note =>
+        ? state.notes.map((note) =>
             state.selectedNotesIds.includes(note.id)
               ? { ...note, category: payload.categoryId }
               : note
           )
-        : state.notes.map(note =>
+        : state.notes.map((note) =>
             note.id === payload.noteId ? { ...note, category: payload.categoryId } : note
           ),
     }),
@@ -69,7 +69,7 @@ const noteSlice = createSlice({
     }),
     deleteNotes: (state, { payload }: PayloadAction<string[]>) => ({
       ...state,
-      notes: state.notes.filter(note => !payload.includes(note.id)),
+      notes: state.notes.filter((note) => !payload.includes(note.id)),
       activeNoteId: getNewActiveNoteId(
         state.notes,
         state.activeNoteId,
@@ -85,9 +85,9 @@ const noteSlice = createSlice({
         ),
       ],
     }),
-    emptyTrash: state => ({
+    emptyTrash: (state) => ({
       ...state,
-      notes: state.notes.filter(note => !note.trash),
+      notes: state.notes.filter((note) => !note.trash),
     }),
     loadNotes: () => initialState,
     loadNotesError: (state, { payload }: PayloadAction<string>) => ({
@@ -102,10 +102,10 @@ const noteSlice = createSlice({
       selectedNotesIds: [getFirstNoteId(Folder.ALL, payload)],
       loading: false,
     }),
-    pruneNotes: state => ({
+    pruneNotes: (state) => ({
       ...state,
       notes: state.notes.filter(
-        note => note.text !== '' || state.selectedNotesIds.includes(note.id)
+        (note) => note.text !== '' || state.selectedNotesIds.includes(note.id)
       ),
     }),
     searchNotes: (state, { payload }: PayloadAction<string>) => ({
@@ -138,20 +138,30 @@ const noteSlice = createSlice({
     toggleFavoriteNote: (state, { payload }: PayloadAction<string>) => ({
       ...state,
       notes: state.selectedNotesIds.includes(payload)
-        ? state.notes.map(note =>
+        ? state.notes.map((note) =>
             state.selectedNotesIds.includes(note.id) ? { ...note, favorite: !note.favorite } : note
           )
-        : state.notes.map(note =>
+        : state.notes.map((note) =>
             note.id === payload ? { ...note, favorite: !note.favorite } : note
           ),
+    }),
+    restoreTrashedNote: (state, { payload }: PayloadAction<string>) => ({
+      ...state,
+      notes: state.selectedNotesIds.includes(payload)
+        ? state.notes.map((note) =>
+            state.selectedNotesIds.includes(note.id) && note.trash
+              ? { ...note, trash: !note.trash }
+              : note
+          )
+        : state.notes.map((note) => note),
     }),
     toggleTrashedNote: (state, { payload }: PayloadAction<string>) => ({
       ...state,
       notes: state.selectedNotesIds.includes(payload)
-        ? state.notes.map(note =>
+        ? state.notes.map((note) =>
             state.selectedNotesIds.includes(note.id) ? { ...note, trash: !note.trash } : note
           )
-        : state.notes.map(note => (note.id === payload ? { ...note, trash: !note.trash } : note)),
+        : state.notes.map((note) => (note.id === payload ? { ...note, trash: !note.trash } : note)),
       activeNoteId: getNewActiveNoteId(
         state.notes,
         payload,
@@ -164,7 +174,7 @@ const noteSlice = createSlice({
     }),
     addFavoriteNote: (state, { payload }: PayloadAction<string>) => ({
       ...state,
-      notes: state.notes.map(note => {
+      notes: state.notes.map((note) => {
         if (state.selectedNotesIds.includes(payload)) {
           return state.selectedNotesIds.includes(note.id) ? { ...note, favorite: true } : note
         }
@@ -177,7 +187,7 @@ const noteSlice = createSlice({
     }),
     addTrashedNote: (state, { payload }: PayloadAction<string>) => ({
       ...state,
-      notes: state.notes.map(note => {
+      notes: state.notes.map((note) => {
         if (state.selectedNotesIds.includes(payload)) {
           return state.selectedNotesIds.includes(note.id) ? { ...note, trash: true } : note
         }
@@ -199,7 +209,7 @@ const noteSlice = createSlice({
     }),
     updateNote: (state, { payload }: PayloadAction<NoteItem>) => ({
       ...state,
-      notes: state.notes.map(note =>
+      notes: state.notes.map((note) =>
         note.id === payload.id
           ? { ...note, text: payload.text, lastUpdated: payload.lastUpdated }
           : note
@@ -214,7 +224,7 @@ const noteSlice = createSlice({
         ? state.selectedNotesIds.length === 1 && state.selectedNotesIds[0] === noteId
           ? state.selectedNotesIds
           : state.selectedNotesIds.includes(noteId)
-          ? state.selectedNotesIds.filter(selectedNoteId => selectedNoteId !== noteId)
+          ? state.selectedNotesIds.filter((selectedNoteId) => selectedNoteId !== noteId)
           : [...state.selectedNotesIds, noteId]
         : [noteId],
     }),
@@ -240,6 +250,7 @@ export const {
   addTrashedNote,
   updateNote,
   updateSelectedNotes,
+  restoreTrashedNote,
 } = noteSlice.actions
 
 export default noteSlice.reducer

--- a/tests/e2e/integration/note.test.ts
+++ b/tests/e2e/integration/note.test.ts
@@ -605,4 +605,29 @@ describe('Manage notes test', () => {
       cy.get('.note-list-each').should('have.length', 3)
     })
   })
+
+  it('should not move a note that is already in Notes when dragged & dropped on Notes', () => {
+    createXUniqueNotes(3)
+
+    holdKeyAndClickNoteAtIndex(0, 'meta')
+
+    dragAndDrop('[data-testid=note-list-item-0]', '[data-testid=notes]')
+
+    cy.get('[data-testid=note-list]').within(() => {
+      cy.get('.note-list-each').should('have.length', 3)
+    })
+  })
+
+  it('should not move multiple notes that are already in Notes when dragged & dropped on Notes', () => {
+    createXUniqueNotes(3)
+
+    holdKeyAndClickNoteAtIndex(0, 'meta')
+    holdKeyAndClickNoteAtIndex(2, 'meta')
+
+    dragAndDrop('[data-testid=note-list-item-0]', '[data-testid=notes]')
+
+    cy.get('[data-testid=note-list]').within(() => {
+      cy.get('.note-list-each').should('have.length', 3)
+    })
+  })
 })


### PR DESCRIPTION
- [x] Please read the [Contribution Guidelines](../CONTRIBUTING.md) before opening a pull request.

## Description

- [x] Fixed a bug where ```Note```s already in the ```Notes``` folder would be moved to the ```Trash``` folder if they were dragged and dropped on the ```Notes``` folder.

- [x] Two Cypress tests were added to add coverage to this potential user interaction.

This bug occurred due to the re-use of the ```toggleTrashedNote``` action. This action has no logic to prevent the toggle, so a new action called ```restoreTrashedNote``` was created. This new action will only change a ```Note```'s ```trash``` property if it is already in the ```Trash``` folder.

Fixes #355 

## Browser Checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
