### PR TITLE
Toggle favorite text, fix bug #375

### DIFF
--- a/src/client/containers/ContextMenuOptions.tsx
+++ b/src/client/containers/ContextMenuOptions.tsx
@@ -100,6 +100,10 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
   const { selectedNotesIds, notes } = useSelector(getNotes)
   const { categories } = useSelector(getCategories)
 
+  const selectedNotes = notes.filter((note) => selectedNotesIds.includes(note.id))
+  const isSelectedNotesDiffFavor =
+    selectedNotes.filter((note) => note.favorite !== selectedNotes[0].favorite).length > 0
+
   // ===========================================================================
   // Dispatch
   // ===========================================================================
@@ -123,9 +127,7 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
   const deleteNotesHandler = () => _deleteNotes(selectedNotesIds)
   const downloadNotesHandler = () =>
     downloadNotes(
-      selectedNotesIds.includes(clickedNote.id)
-        ? notes.filter((note) => selectedNotesIds.includes(note.id))
-        : [clickedNote],
+      selectedNotesIds.includes(clickedNote.id) ? selectedNotes : [clickedNote],
       categories
     )
   const favoriteNoteHandler = () => _toggleFavoriteNotes(clickedNote.id)
@@ -160,7 +162,13 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
             dataTestID={TestID.NOTE_OPTION_FAVORITE}
             handler={favoriteNoteHandler}
             icon={Star}
-            text={clickedNote.favorite ? LabelText.REMOVE_FAVORITE : LabelText.MARK_AS_FAVORITE}
+            text={
+              isSelectedNotesDiffFavor
+                ? LabelText.TOGGLE_FAVORITE
+                : clickedNote.favorite
+                ? LabelText.REMOVE_FAVORITE
+                : LabelText.MARK_AS_FAVORITE
+            }
           />
           <ContextMenuOption
             dataTestID={TestID.NOTE_OPTION_TRASH}

--- a/src/client/containers/ContextMenuOptions.tsx
+++ b/src/client/containers/ContextMenuOptions.tsx
@@ -101,8 +101,9 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
   const { categories } = useSelector(getCategories)
 
   const selectedNotes = notes.filter((note) => selectedNotesIds.includes(note.id))
-  const isSelectedNotesDiffFavor =
-    selectedNotes.filter((note) => note.favorite !== selectedNotes[0].favorite).length > 0
+  const isSelectedNotesDiffFavor = Boolean(
+    selectedNotes.find((note) => note.favorite) && selectedNotes.find((note) => !note.favorite)
+  )
 
   // ===========================================================================
   // Dispatch

--- a/src/resources/LabelText.ts
+++ b/src/resources/LabelText.ts
@@ -22,4 +22,5 @@ export enum LabelText {
   RENAME = 'Rename category',
   ADD_CONTENT_NOTE = 'Please add content to this new note to access the menu options.',
   DOWNLOAD_ALL_NOTES = 'Download all notes',
+  TOGGLE_FAVORITE = 'Toggle favorite',
 }


### PR DESCRIPTION
## Description

Change text in context menu to "Toggle favorite" when selected notes has different favorite state. 

Closes #375

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari
