### PR TITLE
Fixes #390

### DIFF
--- a/src/client/components/Tabs/Tabs.tsx
+++ b/src/client/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, Fragment } from 'react'
 
 import { Tab } from './Tab'
 
@@ -31,10 +31,10 @@ export const Tabs: React.FC<TabsProps> = ({ children }) => {
           if (child.props.label !== activeTab) return
 
           return (
-            <>
+            <Fragment key={child.props.label}>
               <h3>{child.props.label}</h3>
               {child.props.children}
-            </>
+            </Fragment>
           )
         })}
       </div>


### PR DESCRIPTION
## Description

Tab content children rendered in `Tabs.tsx` were missing key prop. Changed fragment from shorthand syntax and provided label as unique key. 

Closes #390 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Testing checklist

- [x] End-to-end tests have been created if necessary
