### PR TITLE
Fix: ensure settings menu is closed on log in

### DIFF
--- a/src/client/api/index.ts
+++ b/src/client/api/index.ts
@@ -63,5 +63,5 @@ export const saveState = ({ categories, notes }: SyncPayload) =>
     })
   })
 
-export const saveSettings = (settings: SettingsState) =>
+export const saveSettings = ({ isOpen, ...settings }: SettingsState) =>
   Promise.resolve(localStorage.setItem('settings', JSON.stringify(settings)))

--- a/src/client/slices/auth.ts
+++ b/src/client/slices/auth.ts
@@ -34,6 +34,8 @@ const authSlice = createSlice({
     },
 
     logoutSuccess: (state) => {
+      localStorage.clear()
+
       state.isAuthenticated = false
       state.currentUser = {}
       state.error = ''

--- a/src/client/slices/auth.ts
+++ b/src/client/slices/auth.ts
@@ -34,8 +34,6 @@ const authSlice = createSlice({
     },
 
     logoutSuccess: (state) => {
-      localStorage.clear()
-
       state.isAuthenticated = false
       state.currentUser = {}
       state.error = ''


### PR DESCRIPTION
## Description

Save settings to local storage without `isOpen` to ensure the settings menu is closed on login.

Closes #372

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
