### PR TITLE
Hide NoteBar in Scratchpad view #384

### DIFF
--- a/src/client/containers/TakeNoteApp.tsx
+++ b/src/client/containers/TakeNoteApp.tsx
@@ -11,7 +11,12 @@ import { NoteList } from '@/containers/NoteList'
 import { SettingsModal } from '@/containers/SettingsModal'
 import { TempStateProvider } from '@/contexts/TempStateContext'
 import { useInterval, useBeforeUnload } from '@/utils/hooks'
-import { getWebsiteTitle, determineAppClass, getActiveCategory } from '@/utils/helpers'
+import {
+  getWebsiteTitle,
+  determineAppClass,
+  getActiveCategory,
+  getNoteBarConf,
+} from '@/utils/helpers'
 import { loadCategories, swapCategories } from '@/slices/category'
 import { loadNotes } from '@/slices/note'
 import { sync } from '@/slices/sync'
@@ -90,7 +95,7 @@ export const TakeNoteApp: React.FC = () => {
           <DragDropContext onDragEnd={onDragEnd}>
             <SplitPane split="vertical" minSize={150} maxSize={500} defaultSize={240}>
               <AppSidebar />
-              <SplitPane split="vertical" minSize={200} maxSize={600} defaultSize={330}>
+              <SplitPane split="vertical" {...getNoteBarConf(activeFolder)}>
                 <NoteList />
                 <NoteEditor />
               </SplitPane>

--- a/src/client/utils/helpers.ts
+++ b/src/client/utils/helpers.ts
@@ -218,3 +218,31 @@ export const debounceEvent = <T extends Function>(cb: T, wait = 20) => {
 export const isDraftNote = (note: NoteItem) => {
   return note.text === ''
 }
+
+export const getNoteBarConf = (
+  activeFolder: Folder
+): {
+  minSize?: number
+  maxSize?: number
+  defaultSize?: number
+  allowResize?: boolean
+  resizerStyle?: React.CSSProperties
+} => {
+  switch (activeFolder) {
+    case Folder.SCRATCHPAD:
+      return {
+        minSize: 0,
+        maxSize: 0,
+        defaultSize: 0,
+        allowResize: false,
+        resizerStyle: { display: 'none' },
+      }
+
+    default:
+      return {
+        minSize: 200,
+        maxSize: 600,
+        defaultSize: 330,
+      }
+  }
+}


### PR DESCRIPTION
## Description

This hides the bar by setting `minSize` and `maxSize` to 0, when `Scratchpad` is opened.
`defaultSize` as well as it would otherwise not change size.
Does not set `size` directly, as this would disable SplitPane from remembering the previous size when returning.
The resizer is hidden to disable the hover effect.

Closes #384

### Browser checklist

This PR has been tested in the following browsers:

- [x] Firefox
- [x] Chrome
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
