### PR TITLE
[Feature] Add line numbers option to settings

### DIFF
--- a/src/client/containers/SettingsModal.tsx
+++ b/src/client/containers/SettingsModal.tsx
@@ -79,6 +79,8 @@ export const SettingsModal: React.FC = () => {
     _updateCodeMirrorOption('styleActiveLine', !codeMirrorOptions.styleActiveLine)
   const toggleScrollPastEnd = () =>
     _updateCodeMirrorOption('scrollPastEnd', !codeMirrorOptions.scrollPastEnd)
+  const toggleLineNumbersHandler = () =>
+    _updateCodeMirrorOption('lineNumbers', !codeMirrorOptions.lineNumbers)
   const handleEscPress = (event: KeyboardEvent) => {
     event.stopPropagation()
     if (event.key === 'Escape' && isOpen) {
@@ -143,6 +145,12 @@ export const SettingsModal: React.FC = () => {
                 description="Controls whether the editor should highlight the active line"
                 toggle={toggleLineHighlight}
                 checked={codeMirrorOptions.styleActiveLine}
+              />
+              <Option
+                title="Display line numbers"
+                description="Controls whether the editor should display line numbers"
+                toggle={toggleLineNumbersHandler}
+                checked={codeMirrorOptions.lineNumbers}
               />
               <Option
                 title="Scroll past end"

--- a/src/client/styles/_new-moon.scss
+++ b/src/client/styles/_new-moon.scss
@@ -1,5 +1,12 @@
 .cm-s-new-moon .CodeMirror-gutters {
   background: #333333 !important;
+  // Remove white border when line numbers are displayed
+  border-right: 0px;
+}
+
+.cm-s-new-moon .CodeMirror-linenumber {
+  // Adjust color of line number
+  color: #4f4f4f;
 }
 
 .cm-s-new-moon .CodeMirror-foldgutter-open,


### PR DESCRIPTION
## Description

Added the ability to display line numbers in the editor as a setting, along with minor CSS tweaks to adjust the display of line numbers.

**Screenshots:**
![Screenshot from 2020-10-25 18-32-42](https://user-images.githubusercontent.com/13074003/97108050-d798a780-16f0-11eb-9913-92475f9f9641.png)
![Screenshot from 2020-10-25 18-32-31](https://user-images.githubusercontent.com/13074003/97108054-db2c2e80-16f0-11eb-85b5-68b884b3ca35.png)
![Screenshot from 2020-10-25 18-36-00](https://user-images.githubusercontent.com/13074003/97108065-fa2ac080-16f0-11eb-9402-ef81d261c61c.png)


Closes #381 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
