### PR TITLE
fix(ContextMenuOption): resolve menu not closing after option be selected

### DIFF
--- a/src/client/components/NoteList/ContextMenuOption.tsx
+++ b/src/client/components/NoteList/ContextMenuOption.tsx
@@ -5,7 +5,7 @@ import { MenuUtilitiesContext } from '@/containers/ContextMenu'
 
 export interface ContextMenuOptionProps {
   dataTestID: string
-  handler: MouseEventHandler | KeyboardEventHandler
+  handler: MouseEventHandler & KeyboardEventHandler
   icon: Icon
   text: string
   optionType?: string

--- a/src/client/components/NoteList/ContextMenuOption.tsx
+++ b/src/client/components/NoteList/ContextMenuOption.tsx
@@ -1,9 +1,11 @@
-import React, { KeyboardEventHandler, MouseEventHandler } from 'react'
+import React, { KeyboardEventHandler, MouseEventHandler, useContext } from 'react'
 import { Icon } from 'react-feather'
+
+import { MenuUtilitiesContext } from '@/containers/ContextMenu'
 
 export interface ContextMenuOptionProps {
   dataTestID: string
-  handler: MouseEventHandler & KeyboardEventHandler
+  handler: MouseEventHandler | KeyboardEventHandler
   icon: Icon
   text: string
   optionType?: string
@@ -17,13 +19,30 @@ export const ContextMenuOption: React.FC<ContextMenuOptionProps> = ({
   text,
   ...rest
 }) => {
+  // ===========================================================================
+  // Context
+  // ===========================================================================
+
+  const { setOptionsId } = useContext(MenuUtilitiesContext)
+
+  // ===========================================================================
+  // Handlers
+  // ===========================================================================
+
+  const optionHandler: MouseEventHandler & KeyboardEventHandler = (
+    event: React.MouseEvent<Element, MouseEvent> & React.KeyboardEvent<Element>
+  ) => {
+    handler(event)
+    setOptionsId('')
+  }
+
   return (
     <div
       data-testid={dataTestID}
       className={optionType === 'delete' ? 'nav-item delete-option' : 'nav-item'}
       role="button"
-      onClick={handler}
-      onKeyPress={handler}
+      onClick={optionHandler}
+      onKeyPress={optionHandler}
       tabIndex={0}
       {...rest}
     >


### PR DESCRIPTION
## Description

Closes #436 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
