### PR TITLE
Fix nodemon.config.json

### DIFF
--- a/config/nodemon.config.json
+++ b/config/nodemon.config.json
@@ -11,5 +11,5 @@
   ],
   "watch": ["src/server/"],
   "ext": "ts",
-  "exec": "NODE_ENV=development node --inspect -r ts-node/register ./src/server/index.ts"
+  "exec": "cross-env NODE_ENV=development node --inspect -r ts-node/register ./src/server/index.ts"
 }


### PR DESCRIPTION
## Description

Enable exec on windows，just fix it！

error: 'NODE_ENV' is not recognized as an internal or external command,
