### PR TITLE
Escape commands run by concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": false,
   "main": "src/server/index.ts",
   "scripts": {
-    "dev": "concurrently 'npm run server' 'npm run client'",
+    "dev": "concurrently \"npm run server\" \"npm run client\"",
     "client": "cross-env NODE_ENV=development webpack serve --config config/webpack.dev.js",
     "server": "nodemon --config config/nodemon.config.json",
     "build": "cross-env NODE_ENV=production webpack --config config/webpack.prod.js",


### PR DESCRIPTION
## Description

Fixes issue where `npm run dev` was failing on Windows due to single quotes wrapping npm commands run by `concurrently`.

Closes #446 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
