### PR TITLE
Tests for Toggle DarkModel have been implemented

### DIFF
--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -144,7 +144,11 @@ export const NoteMenuBar = () => {
         >
           {syncing ? <Loader size={18} className="rotating-svg" /> : <RefreshCw size={18} />}
         </button>
-        <button className="note-menu-bar-button" onClick={toggleDarkThemeHandler}>
+        <button
+          className="note-menu-bar-button"
+          onClick={toggleDarkThemeHandler}
+          data-testid={TestID.DARK_MODE_TOGGLE}
+        >
           {darkTheme ? <Sun size={18} /> : <Moon size={18} />}
         </button>
 

--- a/tests/unit/client/containers/NoteMenuBar.test.tsx
+++ b/tests/unit/client/containers/NoteMenuBar.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import { TestID } from '@resources/TestID'
+import { NoteMenuBar } from '@/containers/NoteMenuBar'
+
+import { renderWithRouter } from '../testHelpers'
+
+const wrap = () => renderWithRouter(<NoteMenuBar />)
+
+describe('<NoteMenuBar />', () => {
+  it('renders the NoteMenuBar', () => {
+    const component = wrap()
+
+    expect(component).toBeTruthy()
+  })
+  it('toggle dark mode on and off', () => {
+    const component = wrap()
+    fireEvent.click(component.getByTestId(TestID.DARK_MODE_TOGGLE))
+    fireEvent.click(component.getByTestId(TestID.DARK_MODE_TOGGLE))
+  })
+})


### PR DESCRIPTION
## Description

- Create tests for rendering the NoteMenubar for Dark Theme button.
 - create test for clicking the moon button to switch from light  to Dark Theme..

Closes #419 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
