### PR TITLE
Change Colors to VS Code colors

### DIFF
--- a/src/client/styles/_dark.scss
+++ b/src/client/styles/_dark.scss
@@ -1,5 +1,5 @@
 $dark-sidebar: #333;
-$dark-editor: #3f3f3f;
+$dark-editor: #1E1E1E;
 
 .dark {
   a {

--- a/src/client/styles/_light-theme.scss
+++ b/src/client/styles/_light-theme.scss
@@ -1,5 +1,5 @@
 .cm-s-base16-light {
   span.cm-string {
-    color: #90a959;
+    color: #FFFFF;
   }
 }


### PR DESCRIPTION
## Description

The dark theme is now #1E1E1E color, and light is standard #FFFFF, to match VS Code light and dark themes, for a more familiar feel for developers

### Browser checklist

This PR has been tested in the following browsers:

- [Y] Chrome
- [N] Firefox
- [Y] Safari

### Testing checklist

- [N/A] End-to-end tests have been created if necessary
