### PR TITLE
fix: space at bottom for previewer content

### DIFF
--- a/src/client/styles/_previewer.scss
+++ b/src/client/styles/_previewer.scss
@@ -7,6 +7,9 @@
   padding: 1rem;
   -webkit-font-smoothing: subpixel-antialiased;
 
+  padding-bottom: 0px;
+  bottom: 39px;
+
   &_direction-ltr {
     direction: ltr;
   }


### PR DESCRIPTION
## Description

As the issue #496 mentioned, for browser: firefox, when a long content is written and then previewed, the content at the end is not displayed as intended (hides behind the bottom toolbar), these changes fix that by using ``` bottom: 39px ``` instead of ``` padding-bottom: 39px; ```

Closes #496

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
