### PR TITLE
fix: preview overflow from top

### DIFF
--- a/src/client/styles/_previewer.scss
+++ b/src/client/styles/_previewer.scss
@@ -8,6 +8,7 @@
   -webkit-font-smoothing: subpixel-antialiased;
 
   padding-bottom: 0px;
+  top: 0px;
   bottom: 39px;
 
   &_direction-ltr {


### PR DESCRIPTION
## Description

In order to fix overflowing from the top **of previewer** I have used `top: 0px` as we're using `bottom: 39px`

Closes #501 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
