### PR TITLE
[Feature] Add title attribute to buttons in the Note Menu Bar and Bring the Note Menu Bar to Top in order to follow Fitt's Law of Human Computer Interaction UX Design

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "react-split-pane": "^0.1.92",
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
+    "remove-markdown": "^0.3.0",
+    "speak-tts": "^2.0.8",
     "stream-browserify": "^3.0.0",
     "unist-util-visit": "^2.0.3",
     "uuid": "^8.3.1"

--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -27,6 +27,7 @@ import { toggleFavoriteNotes, toggleTrashNotes } from '@/slices/note'
 import { getCategories, getNotes, getSync, getSettings } from '@/selectors'
 import { downloadNotes, isDraftNote, getShortUuid, copyToClipboard } from '@/utils/helpers'
 import { sync } from '@/slices/sync'
+import { TTSBar } from './TTSBar'
 
 export const NoteMenuBar = () => {
   // ===========================================================================
@@ -137,6 +138,8 @@ export const NoteMenuBar = () => {
             {copyNoteIcon}
             {uuidCopiedText && <span className="uuid-copied-text">{uuidCopiedText}</span>}
           </button>
+
+          <TTSBar text={activeNote.text}></TTSBar>
         </nav>
       ) : (
         <div />

--- a/src/client/containers/TTSBar.tsx
+++ b/src/client/containers/TTSBar.tsx
@@ -1,0 +1,83 @@
+import React, { Fragment, useState } from 'react'
+import { Pause, Play, Square } from 'react-feather'
+import Speech from 'speak-tts'
+import removeMd from 'remove-markdown'
+
+
+const initSpeechTTS = () => {
+  const speech = new Speech()
+  console.log('Speech: initializing..');
+
+  speech.init({
+    'volume': 1,
+    'lang': 'en-GB',
+    'rate': 1,
+    'pitch': 1,
+    'voice': 'Google UK English Male',
+    'splitSentences': true,
+    'listeners': {
+      'onvoiceschanged': (voices) => {
+        console.log("Event voiceschanged", voices)
+      }
+    }
+  }).then((data: any) => {
+    // The 'data' object contains the list of available voices and the voice synthesis params
+    console.log('Speech: init success : ', data)
+  }).catch((e: any) => {
+    console.error('Speech: init failed : ', e)
+  })
+
+  return speech
+}
+
+
+export interface TTSBarProps {
+  text: String
+}
+
+enum Status {
+  idle,
+  playing
+}
+
+
+export const TTSBar: React.FC<TTSBarProps> = ({ text }) => {
+
+  const [speech] = useState(initSpeechTTS)
+  const [status, setStatus] = useState(Status.idle)
+
+  text = removeMd(text)
+  
+  return (
+    <Fragment>
+      <button
+        className='note-menu-bar-button uuid'
+        onClick={() => {
+          if (status === Status.idle) {
+            speech.speak({
+              text: text,
+              queue: false, // current speech will be interrupted
+              listeners: {
+                onend: () => {
+                  console.log("End utterance")
+                  setStatus(Status.idle)
+                },
+                onstart: () => {
+                  console.log("Start utterance")
+                  setStatus(Status.playing)
+                },
+              }
+            })
+          }
+
+          if (status === Status.playing) {
+            speech.cancel()
+          }
+        }}
+      >
+        {status === Status.idle && <Play size={18}></Play>}
+        {status === Status.playing && <Square size={18}></Square>}
+      </button>
+    </Fragment>
+  )
+}

--- a/src/client/styles/_layout.scss
+++ b/src/client/styles/_layout.scss
@@ -50,7 +50,7 @@
   }
   .editor,
   .previewer {
-    padding-bottom: 38px;
+    padding-top: 49px;
     height: 100vh;
   }
 }

--- a/src/client/styles/_note-menu-bar.scss
+++ b/src/client/styles/_note-menu-bar.scss
@@ -1,11 +1,12 @@
 .note-menu-bar {
-  height: 39px;
+  height: 49px;
   border-bottom: 1px solid darken($note-sidebar-color, 5%);
   background: $note-sidebar-color;
   display: flex;
   align-items: center;
   justify-content: space-between;
   position: absolute;
+  top: 0;
   left: 0;
   width: 100%;
   z-index: 99;

--- a/src/client/styles/_note-menu-bar.scss
+++ b/src/client/styles/_note-menu-bar.scss
@@ -1,15 +1,15 @@
 .note-menu-bar {
   height: 39px;
-  border-top: 1px solid darken($note-sidebar-color, 5%);
+  border-bottom: 1px solid darken($note-sidebar-color, 5%);
   background: $note-sidebar-color;
   display: flex;
   align-items: center;
   justify-content: space-between;
   position: absolute;
-  bottom: 0;
   left: 0;
   width: 100%;
   z-index: 99;
+  height: 49px;
 
   nav {
     display: flex;


### PR DESCRIPTION
## Description

Added tooltips for the icons in the note menu bar.
Placed the note menu bar on top of the editor because of the universal design practices and to follow Fitt's law of human-computer interactions. According to this law, the time required for a person to move a pointer to the note menu bar is high if it is placed bottom of the editor.  Most web applications place this kind of menu bar on top of the editor.

Closes # https://github.com/taniarascia/takenote/issues/456

### Browser checklist

This PR has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Tested for the above browsers.