### PR TITLE
[Feature] Add title attribute to buttons in the Note Menu Bar and Bring the Note Menu Bar to Top in order to follow Fitt's Law of Human Computer Interaction UX Design

### DIFF
--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -107,6 +107,7 @@ export const NoteMenuBar = () => {
       {activeNote && !isDraftNote(activeNote) ? (
         <nav>
           <button
+            title="Preview mode"
             className="note-menu-bar-button"
             onClick={togglePreviewHandler}
             data-testid={TestID.PREVIEW_MODE}
@@ -123,11 +124,12 @@ export const NoteMenuBar = () => {
               </button>
             </>
           )}
-          <button className="note-menu-bar-button">
+          <button className="note-menu-bar-button" title="Download note">
             <Download size={18} onClick={downloadNotesHandler} />
           </button>
           <button
             className="note-menu-bar-button uuid"
+            title="Copy text"
             onClick={() => {
               copyToClipboard(`{{${shortNoteUuid}}}`)
               setUuidCopiedText(successfulCopyMessage)
@@ -145,16 +147,17 @@ export const NoteMenuBar = () => {
         <LastSyncedNotification datetime={lastSynced} pending={pendingSync} syncing={syncing} />
         <button
           className="note-menu-bar-button"
+          title="Sync notes"
           onClick={syncNotesHandler}
           data-testid={TestID.TOPBAR_ACTION_SYNC_NOTES}
         >
           {syncing ? <Loader size={18} className="rotating-svg" /> : <RefreshCw size={18} />}
         </button>
-        <button className="note-menu-bar-button" onClick={toggleDarkThemeHandler}>
+        <button className="note-menu-bar-button" title="Dark mode" onClick={toggleDarkThemeHandler}>
           {darkTheme ? <Sun size={18} /> : <Moon size={18} />}
         </button>
 
-        <button className="note-menu-bar-button" onClick={settingsHandler}>
+        <button className="note-menu-bar-button" title="Settings" onClick={settingsHandler}>
           <Settings aria-hidden size={18} />
           <span className="sr-only">Settings</span>
         </button>

--- a/src/client/styles/_layout.scss
+++ b/src/client/styles/_layout.scss
@@ -50,7 +50,7 @@
   }
   .editor,
   .previewer {
-    padding-bottom: 38px;
+    padding-top: 49px;
     height: 100vh;
   }
 }

--- a/src/client/styles/_note-menu-bar.scss
+++ b/src/client/styles/_note-menu-bar.scss
@@ -1,15 +1,15 @@
 .note-menu-bar {
   height: 39px;
-  border-top: 1px solid darken($note-sidebar-color, 5%);
+  border-bottom: 1px solid darken($note-sidebar-color, 5%);
   background: $note-sidebar-color;
   display: flex;
   align-items: center;
   justify-content: space-between;
   position: absolute;
-  bottom: 0;
   left: 0;
   width: 100%;
   z-index: 99;
+  height: 49px;
 
   nav {
     display: flex;


### PR DESCRIPTION
Added tooltips for the icons in the note menu bar.
Placed the note menu bar on top of the editor because of the universal design practices and to follow Fitt's law of human-computer interactions. According to this law, the time required for a person to move a pointer to the note menu bar is high if it is placed bottom of the editor. Most web applications place this kind of menu bar on top of the editor.

Closes # #456

Browser checklist
This PR has been tested in the following browsers:

 Chrome
 Firefox
 Safari
Tested for the above browsers.

Tested for the above browsers.