### PR TITLE
Add hover colors to all icons

### DIFF
--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -107,7 +107,7 @@ export const NoteMenuBar = () => {
       {activeNote && !isDraftNote(activeNote) ? (
         <nav>
           <button
-            className="note-menu-bar-button icon-hover"
+            className="note-menu-bar-button eye"
             onClick={togglePreviewHandler}
             data-testid={TestID.PREVIEW_MODE}
           >
@@ -123,7 +123,7 @@ export const NoteMenuBar = () => {
               </button>
             </>
           )}
-          <button className="note-menu-bar-button icon-hover">
+          <button className="note-menu-bar-button download">
             <Download size={18} onClick={downloadNotesHandler} />
           </button>
           <button
@@ -144,17 +144,17 @@ export const NoteMenuBar = () => {
       <nav>
         <LastSyncedNotification datetime={lastSynced} pending={pendingSync} syncing={syncing} />
         <button
-          className="note-menu-bar-button icon-hover"
+          className="note-menu-bar-button reload"
           onClick={syncNotesHandler}
           data-testid={TestID.TOPBAR_ACTION_SYNC_NOTES}
         >
           {syncing ? <Loader size={18} className="rotating-svg" /> : <RefreshCw size={18} />}
         </button>
-        <button className="note-menu-bar-button icon-hover" onClick={toggleDarkThemeHandler}>
+        <button className="note-menu-bar-button moon" onClick={toggleDarkThemeHandler}>
           {darkTheme ? <Sun size={18} /> : <Moon size={18} />}
         </button>
 
-        <button className="note-menu-bar-button icon-hover" onClick={settingsHandler}>
+        <button className="note-menu-bar-button setting" onClick={settingsHandler}>
           <Settings aria-hidden size={18} />
           <span className="sr-only">Settings</span>
         </button>

--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -107,7 +107,7 @@ export const NoteMenuBar = () => {
       {activeNote && !isDraftNote(activeNote) ? (
         <nav>
           <button
-            className="note-menu-bar-button"
+            className="note-menu-bar-button icon-hover"
             onClick={togglePreviewHandler}
             data-testid={TestID.PREVIEW_MODE}
           >
@@ -115,7 +115,7 @@ export const NoteMenuBar = () => {
           </button>
           {!activeNote.scratchpad && (
             <>
-              <button className="note-menu-bar-button" onClick={favoriteNoteHandler}>
+              <button className="note-menu-bar-button star" onClick={favoriteNoteHandler}>
                 <Star size={18} />
               </button>
               <button className="note-menu-bar-button trash" onClick={trashNoteHandler}>
@@ -123,11 +123,11 @@ export const NoteMenuBar = () => {
               </button>
             </>
           )}
-          <button className="note-menu-bar-button">
+          <button className="note-menu-bar-button icon-hover">
             <Download size={18} onClick={downloadNotesHandler} />
           </button>
           <button
-            className="note-menu-bar-button uuid"
+            className="note-menu-bar-button uuid icon-hover"
             onClick={() => {
               copyToClipboard(`{{${shortNoteUuid}}}`)
               setUuidCopiedText(successfulCopyMessage)
@@ -144,17 +144,17 @@ export const NoteMenuBar = () => {
       <nav>
         <LastSyncedNotification datetime={lastSynced} pending={pendingSync} syncing={syncing} />
         <button
-          className="note-menu-bar-button"
+          className="note-menu-bar-button icon-hover"
           onClick={syncNotesHandler}
           data-testid={TestID.TOPBAR_ACTION_SYNC_NOTES}
         >
           {syncing ? <Loader size={18} className="rotating-svg" /> : <RefreshCw size={18} />}
         </button>
-        <button className="note-menu-bar-button" onClick={toggleDarkThemeHandler}>
+        <button className="note-menu-bar-button icon-hover" onClick={toggleDarkThemeHandler}>
           {darkTheme ? <Sun size={18} /> : <Moon size={18} />}
         </button>
 
-        <button className="note-menu-bar-button" onClick={settingsHandler}>
+        <button className="note-menu-bar-button icon-hover" onClick={settingsHandler}>
           <Settings aria-hidden size={18} />
           <span className="sr-only">Settings</span>
         </button>

--- a/src/client/styles/_note-menu-bar.scss
+++ b/src/client/styles/_note-menu-bar.scss
@@ -52,15 +52,38 @@
     &.uuid {
       display: flex;
       align-items: center;
+      &:hover {
+        color: $note-icon-color;
+      }
     }
     &.star {
       &:hover {
         color: $yellow;
       }
     }
-    &.icon-hover {
+    &.eye {
       &:hover {
-        color: darken($primary, 20%);
+        color: $primary;
+      }
+    }
+    &.download {
+      &:hover {
+        color: $download-icon-color;
+      }
+    }
+    &.moon {
+      &:hover {
+        color: $moon-icon;
+      }
+    }
+    &.reload {
+      &:hover {
+        color: $reload-icon-color;
+      }
+    }
+    &.setting {
+      &:hover {
+        color: lighten($primary, 10%);
       }
     }
   }

--- a/src/client/styles/_note-menu-bar.scss
+++ b/src/client/styles/_note-menu-bar.scss
@@ -53,6 +53,16 @@
       display: flex;
       align-items: center;
     }
+    &.star {
+      &:hover {
+        color: $yellow;
+      }
+    }
+    &.icon-hover {
+      &:hover {
+        color: darken($primary, 20%);
+      }
+    }
   }
 
   .uuid-copied-text {

--- a/src/client/styles/_variables.scss
+++ b/src/client/styles/_variables.scss
@@ -20,6 +20,10 @@ $accent-lightgray: lighten($accent-gray, 12%);
 $dimmer-background: rgba(0, 0, 0, 0.6);
 $error: #f2777a;
 $yellow: #ffd700;
+$download-icon-color: #2cc56d;
+$note-icon-color: #08475e;
+$reload-icon-color: #f17017;
+$moon-icon: #ebd28b;
 
 $box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.1), 0 2px 4px 0 rgba(0, 0, 0, 0.08);
 

--- a/src/client/styles/_variables.scss
+++ b/src/client/styles/_variables.scss
@@ -19,6 +19,7 @@ $accent-gray: #d0d0d0;
 $accent-lightgray: lighten($accent-gray, 12%);
 $dimmer-background: rgba(0, 0, 0, 0.6);
 $error: #f2777a;
+$yellow: #ffd700;
 
 $box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.1), 0 2px 4px 0 rgba(0, 0, 0, 0.08);
 


### PR DESCRIPTION
## Description
This PR add color to the hover effect of the note icons


Closes #508 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
