### PR TITLE
#438 inserted addOverlay function

### DIFF
--- a/src/client/containers/NoteEditor.tsx
+++ b/src/client/containers/NoteEditor.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs'
 import React from 'react'
 import { Controlled as CodeMirror } from 'react-codemirror2'
 import { useDispatch, useSelector } from 'react-redux'
+import { Editor } from 'codemirror'
 
 import { getActiveNote } from '@/utils/helpers'
 import { updateNote } from '@/slices/note'
@@ -9,7 +10,7 @@ import { NoteItem } from '@/types'
 import { NoteMenuBar } from '@/containers/NoteMenuBar'
 import { EmptyEditor } from '@/components/Editor/EmptyEditor'
 import { PreviewEditor } from '@/components/Editor/PreviewEditor'
-import { getSync, getSettings, getNotes } from '@/selectors'
+import { getNotes, getSettings, getSync } from '@/selectors'
 import { setPendingSync } from '@/slices/sync'
 
 import 'codemirror/lib/codemirror.css'
@@ -40,6 +41,25 @@ export const NoteEditor: React.FC = () => {
     dispatch(updateNote(note))
   }
 
+  const setEditorOverlay = (editor: Editor) => {
+    const query = /\{\{[^}]*}}/g
+    editor.addOverlay({
+      token: function (stream: any) {
+        query.lastIndex = stream.pos
+        var match = query.exec(stream.string)
+        if (match && match.index == stream.pos) {
+          stream.pos += match[0].length || 1
+
+          return 'notelink'
+        } else if (match) {
+          stream.pos = match.index
+        } else {
+          stream.skipToEnd()
+        }
+      },
+    })
+  }
+
   const renderEditor = () => {
     if (loading) {
       return <div className="empty-editor v-center">Loading...</div>
@@ -66,6 +86,7 @@ export const NoteEditor: React.FC = () => {
             editor.focus()
           }, 0)
           editor.setCursor(0)
+          setEditorOverlay(editor)
         }}
         onBeforeChange={(editor, data, value) => {
           _updateNote({

--- a/src/client/styles/_editor.scss
+++ b/src/client/styles/_editor.scss
@@ -32,3 +32,9 @@
 .CodeMirror-activeline-background {
   background: rgba(0, 0, 0, 0.05) !important;
 }
+
+.cm-notelink {
+  font-style: italic;
+  font-weight: bold;
+  color: #0daba3;
+}


### PR DESCRIPTION
## Description
Added the CodeMirror.addOverlay function in order to highlight the syntax of a uuid note link.
The color I used is good both with dark and light mode, feel free to change it if you don't like it or suggest a better one.
Thank you

Closes #438 <-- link the issue number here

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
