### PR TITLE
fix: bug on 'Remove category' option

### DIFF
--- a/src/client/containers/ContextMenuOptions.tsx
+++ b/src/client/containers/ContextMenuOptions.tsx
@@ -13,11 +13,12 @@ import {
   addCategoryToNote,
   updateActiveNote,
   swapFolder,
+  removeCategoryFromNotes,
 } from '@/slices/note'
 import { getCategories, getNotes } from '@/selectors'
 import { Folder, ContextMenuEnum } from '@/utils/enums'
 import { CategoryItem, NoteItem } from '@/types'
-import { setCategoryEdit, deleteCategory } from '@/slices/category'
+import category, { setCategoryEdit, deleteCategory } from '@/slices/category'
 import { MenuUtilitiesContext } from '@/containers/ContextMenu'
 
 export interface ContextMenuOptionsProps {
@@ -45,6 +46,8 @@ const CategoryOptions: React.FC<CategoryOptionsProps> = ({ clickedCategory }) =>
   const dispatch = useDispatch()
 
   const _deleteCategory = (categoryId: string) => dispatch(deleteCategory(categoryId))
+  const _removeCategoryFromNotes = (categoryId: string) =>
+    dispatch(removeCategoryFromNotes(categoryId))
   const _swapFolder = (folder: Folder) => dispatch(swapFolder({ folder }))
   const _setCategoryEdit = (categoryId: string, tempName: string) =>
     dispatch(setCategoryEdit({ id: categoryId, tempName }))
@@ -65,6 +68,7 @@ const CategoryOptions: React.FC<CategoryOptionsProps> = ({ clickedCategory }) =>
   }
   const removeCategoryHandler = () => {
     _deleteCategory(clickedCategory.id)
+    _removeCategoryFromNotes(clickedCategory.id)
     _swapFolder(Folder.ALL)
   }
 

--- a/src/client/slices/note.ts
+++ b/src/client/slices/note.ts
@@ -149,6 +149,12 @@ const noteSlice = createSlice({
           )
     },
 
+    removeCategoryFromNotes: (state, { payload }: PayloadAction<string>) => {
+      state.notes.map((note) => {
+        note.category === payload ? (note.category = '') : note
+      })
+    },
+
     updateActiveNote: (
       state,
       { payload: { noteId, multiSelect } }: PayloadAction<{ noteId: string; multiSelect: boolean }>
@@ -322,6 +328,7 @@ export const {
   updateNotes,
   deleteNotes,
   addCategoryToNote,
+  removeCategoryFromNotes,
   updateActiveNote,
   updateActiveCategoryId,
   swapFolder,

--- a/src/client/slices/note.ts
+++ b/src/client/slices/note.ts
@@ -151,7 +151,9 @@ const noteSlice = createSlice({
 
     removeCategoryFromNotes: (state, { payload }: PayloadAction<string>) => {
       state.notes.map((note) => {
-        note.category === payload ? (note.category = '') : note
+        if (note.category === payload) {
+          note.category = ''
+        }
       })
     },
 

--- a/tests/unit/client/slices/note.test.ts
+++ b/tests/unit/client/slices/note.test.ts
@@ -7,6 +7,7 @@ import reducer, {
   updateNote,
   deleteNotes,
   addCategoryToNote,
+  removeCategoryFromNotes,
   updateActiveNote,
   updateActiveCategoryId,
   swapFolder,
@@ -146,6 +147,74 @@ describe('noteSlice', () => {
         ],
       }
       const result = reducer(initialStateBeforeAddingCategoryToNote, addCategoryToNote(payload))
+
+      expect(result).toEqual(nextState)
+    })
+
+    test('should add Category to the requested note and selected notes', () => {
+      const payload = {
+        categoryId: '3',
+        noteId: '2',
+      }
+      const notes = [createNote({ id: '1' }), createNote({ id: '2' }), createNote({ id: '3' })]
+      const initialStateBeforeAddingCategoryToNote = {
+        ...initialState,
+        notes,
+        selectedNotesIds: ['1', '2'],
+      }
+
+      const nextState = {
+        ...initialStateBeforeAddingCategoryToNote,
+        notes: [
+          {
+            ...notes[0],
+            category: '3',
+          },
+          {
+            ...notes[1],
+            category: '3',
+          },
+          notes[2],
+        ],
+      }
+      const result = reducer(initialStateBeforeAddingCategoryToNote, addCategoryToNote(payload))
+
+      expect(result).toEqual(nextState)
+    })
+  })
+
+  describe('removeCategory', () => {
+    test('should remove Category from the notes', () => {
+      const payload = '1'
+      const notes = [
+        createNote({ id: '1', category: '1' }),
+        createNote({ id: '2', category: '1' }),
+        createNote({ id: '3', category: '2' }),
+        createNote({ id: '4', category: '3' }),
+      ]
+      const initialStateBeforeRemovingCategoryFromNotes = {
+        ...initialState,
+        notes: notes,
+      }
+      const nextState = {
+        ...initialStateBeforeRemovingCategoryFromNotes,
+        notes: [
+          {
+            ...notes[0],
+            category: '',
+          },
+          {
+            ...notes[1],
+            category: '',
+          },
+          notes[2],
+          notes[3],
+        ],
+      }
+      const result = reducer(
+        initialStateBeforeRemovingCategoryFromNotes,
+        removeCategoryFromNotes(payload)
+      )
 
       expect(result).toEqual(nextState)
     })

--- a/tests/unit/client/slices/note.test.ts
+++ b/tests/unit/client/slices/note.test.ts
@@ -218,37 +218,6 @@ describe('noteSlice', () => {
 
       expect(result).toEqual(nextState)
     })
-
-    test('should add Category to the requested note and selected notes', () => {
-      const payload = {
-        categoryId: '3',
-        noteId: '2',
-      }
-      const notes = [createNote({ id: '1' }), createNote({ id: '2' }), createNote({ id: '3' })]
-      const initialStateBeforeAddingCategoryToNote = {
-        ...initialState,
-        notes,
-        selectedNotesIds: ['1', '2'],
-      }
-
-      const nextState = {
-        ...initialStateBeforeAddingCategoryToNote,
-        notes: [
-          {
-            ...notes[0],
-            category: '3',
-          },
-          {
-            ...notes[1],
-            category: '3',
-          },
-          notes[2],
-        ],
-      }
-      const result = reducer(initialStateBeforeAddingCategoryToNote, addCategoryToNote(payload))
-
-      expect(result).toEqual(nextState)
-    })
   })
 
   describe('updateActiveNote', () => {


### PR DESCRIPTION
## Description

This PR fixes the problem mentioned in the issue #520, that is a category was not been removed from its notes when user clicked on 'Delete permanently' option of Categories.

Closes #520 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
