### PR TITLE
Migrate from deprecated node-sass to sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "jest-raw-loader": "^1.0.1",
     "lint-staged": "^10.4.1",
     "mini-css-extract-plugin": "^1.0.0",
-    "node-sass": "^4.14.1",
+    "sass": "^4.14.1",
     "nodemon": "^2.0.5",
     "sass-loader": "^10.0.3",
     "style-loader": "^2.0.0",


### PR DESCRIPTION
## Description

Migrate from deprecated node-sass to sass

Closes #529  <-- link the issue number here

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
