### PR TITLE
Added tooltip on menubar and reusable tooltip component

### DIFF
--- a/src/client/components/Tooltip.tsx
+++ b/src/client/components/Tooltip.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+
+export interface ToolTipProps {
+    content:string,
+    children:JSX.Element | any
+}
+
+const Tooltip : React.FC<ToolTipProps> = ({children,content}) => {
+  const [active, setActive] = useState(false);
+  const showTip = () => {
+      setActive(true);
+  };
+
+  const hideTip = () => {
+    setActive(false);
+  };
+
+  return (
+    <div
+      className="Tooltip-Wrapper"
+      onMouseEnter={showTip}
+      onMouseLeave={hideTip}
+    >
+      {children}
+      {active && (
+        <div className="Tooltip-Tip">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -27,6 +27,7 @@ import { toggleFavoriteNotes, toggleTrashNotes } from '@/slices/note'
 import { getCategories, getNotes, getSync, getSettings } from '@/selectors'
 import { downloadNotes, isDraftNote, getShortUuid, copyToClipboard } from '@/utils/helpers'
 import { sync } from '@/slices/sync'
+import Tooltip from '@/components/Tooltip'
 
 export const NoteMenuBar = () => {
   // ===========================================================================
@@ -111,27 +112,44 @@ export const NoteMenuBar = () => {
             onClick={togglePreviewHandler}
             data-testid={TestID.PREVIEW_MODE}
           >
+          <Tooltip 
+              content={isToggled ? 'Edit note' : 'Preview note'}
+          >
             {isToggled ? (
               <Edit aria-hidden="true" size={18} />
             ) : (
               <Eye aria-hidden="true" size={18} />
             )}
+               </Tooltip>
             <span className="sr-only">{isToggled ? 'Edit note' : 'Preview note'}</span>
           </button>
           {!activeNote.scratchpad && (
             <>
               <button className="note-menu-bar-button" onClick={favoriteNoteHandler}>
+              <Tooltip
+                content="Add to favorites"
+              >
                 <Star aria-hidden="true" size={18} />
+                </Tooltip>
                 <span className="sr-only">Add note to favorites</span>
               </button>
+
               <button className="note-menu-bar-button trash" onClick={trashNoteHandler}>
+              <Tooltip 
+                content="Delete note"
+              >
                 <Trash2 aria-hidden="true" size={18} />
+              </Tooltip>
                 <span className="sr-only">Delete note</span>
               </button>
             </>
           )}
           <button className="note-menu-bar-button">
+          <Tooltip
+            content="Download note"
+          >
             <Download aria-hidden="true" size={18} onClick={downloadNotesHandler} />
+          </Tooltip>
             <span className="sr-only">Download note</span>
           </button>
           <button
@@ -142,9 +160,13 @@ export const NoteMenuBar = () => {
             }}
             data-testid={TestID.UUID_MENU_BAR_COPY_ICON}
           >
+            <Tooltip 
+              content="Download note"
+            >
             {copyNoteIcon}
             {uuidCopiedText && <span className="uuid-copied-text">{uuidCopiedText}</span>}
             <span className="sr-only">Copy note</span>
+            </Tooltip>
           </button>
         </nav>
       ) : (
@@ -157,21 +179,29 @@ export const NoteMenuBar = () => {
           onClick={syncNotesHandler}
           data-testid={TestID.TOPBAR_ACTION_SYNC_NOTES}
         >
+          <Tooltip
+                content={syncing?"Syncing":"Refresh"}
+                >
           {syncing ? (
             <Loader aria-hidden="true" size={18} className="rotating-svg" />
           ) : (
             <RefreshCw aria-hidden="true" size={18} />
           )}
+          </Tooltip>
           <span className="sr-only">Sync notes</span>
         </button>
         <button className="note-menu-bar-button" onClick={toggleDarkThemeHandler}>
+          <Tooltip content="Change Theme">
           {darkTheme ? <Sun aria-hidden="true" size={18} /> : <Moon aria-hidden="true" size={18} />}
           <span className="sr-only">Themes</span>
+          </Tooltip>
         </button>
 
         <button className="note-menu-bar-button" onClick={settingsHandler}>
+        <Tooltip content="Setting">
           <Settings aria-hidden="true" size={18} />
           <span className="sr-only">Settings</span>
+        </Tooltip>
         </button>
       </nav>
     </section>

--- a/src/client/styles/_tooltip.scss
+++ b/src/client/styles/_tooltip.scss
@@ -1,0 +1,20 @@
+.Tooltip-Wrapper {
+  display: inline-block;
+  position: relative;
+}
+
+.Tooltip-Tip {
+  position: absolute;
+  border-radius: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 6px;
+  color: white;
+  background: black;
+  font-size: 14px;
+  font-family: sans-serif;
+  line-height: 1;
+  z-index: 100;
+  white-space: nowrap;
+  top: calc(30px * -1);
+}

--- a/src/client/styles/index.scss
+++ b/src/client/styles/index.scss
@@ -15,5 +15,5 @@
 @import 'tabs';
 @import 'helpers';
 @import 'landing-page';
-
+@import 'tooltip';
 @import 'dark';


### PR DESCRIPTION
## Description

Added Tool Tip on note bottom menu bar for good user experience. I created a reusable tooltip component. so, the tooltip component can be used anywhere

Please read the [Contribution Guidelines](../CONTRIBUTING.md) before opening a pull request. Include a summary of the change and which issue is fixed.

Closes # <-- link the issue number here

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
