### PR TITLE
Fixes shortcuts for MacOs & dark mode for  the first visit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "takenote",
       "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
@@ -1894,7 +1895,6 @@
         "jest-resolve": "^26.5.2",
         "jest-util": "^26.5.2",
         "jest-worker": "^26.5.0",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -5861,7 +5861,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -11706,12 +11705,6 @@
       "dev": true,
       "dependencies": {
         "imagemin": "^7.0.1",
-        "imagemin-gifsicle": "^7.0.0",
-        "imagemin-mozjpeg": "^9.0.0",
-        "imagemin-optipng": "^8.0.0",
-        "imagemin-pngquant": "^9.0.1",
-        "imagemin-svgo": "^8.0.0",
-        "imagemin-webp": "^6.0.0",
         "loader-utils": "^2.0.0",
         "object-assign": "^4.1.1",
         "schema-utils": "^2.7.1"
@@ -13865,7 +13858,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.5.0",
@@ -26225,7 +26217,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/src/client/components/Editor/EmptyEditor.tsx
+++ b/src/client/components/Editor/EmptyEditor.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isMacOs } from 'react-device-detect'
 
 export const EmptyEditor: React.FC = () => {
   return (
@@ -8,7 +9,7 @@ export const EmptyEditor: React.FC = () => {
           <strong>Create a note</strong>
         </p>
         <p>
-          <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>N</kbd>
+          <kbd>{isMacOs ? '⌃' : 'CTRL'}</kbd> + <kbd>{isMacOs ? '⌥' : 'ALT'}</kbd> + <kbd>N</kbd>
         </p>
       </div>
     </div>

--- a/src/client/components/SettingsModal/Shortcut.tsx
+++ b/src/client/components/SettingsModal/Shortcut.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isMacOs } from 'react-device-detect'
 
 export interface ShortcutProps {
   action: string
@@ -10,7 +11,8 @@ export const Shortcut: React.FC<ShortcutProps> = ({ action, letter }) => {
     <div className="settings-shortcut">
       <div>{action}</div>
       <div className="keys">
-        <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>{letter}</kbd>
+        <kbd>{isMacOs ? '⌃' : 'CTRL'}</kbd> + <kbd>{isMacOs ? '⌥' : 'ALT'}</kbd> +{' '}
+        <kbd>{letter}</kbd>
       </div>
     </div>
   )

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -11,6 +11,7 @@ import rootReducer from '@/slices'
 import history from '@/utils/history'
 
 import '@/styles/index.scss'
+import { toggleDarkTheme, updateCodeMirrorOption } from './slices/settings'
 
 const sagaMiddleware = createSagaMiddleware()
 const store = configureStore({
@@ -18,6 +19,17 @@ const store = configureStore({
   middleware: [sagaMiddleware, ...getDefaultMiddleware({ thunk: false })],
   devTools: process.env.NODE_ENV !== 'production',
 })
+
+const { darkTheme } = store.getState().settingsState
+
+if (!darkTheme) {
+  if (typeof window !== 'undefined') {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      store.dispatch(toggleDarkTheme())
+      store.dispatch(updateCodeMirrorOption({ key: 'theme', value: 'new-moon' }))
+    }
+  }
+}
 
 sagaMiddleware.run(rootSaga)
 


### PR DESCRIPTION
## Description
1. For macOS, I have changed the shortcut key icons.
2. Added dark mode feature if the user visits for the first time and if the device is dark enabled.

Closes #535 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari

### Testing checklist

- [x] End-to-end tests have been created if necessary
