### PR TITLE
Fixed non-sticky nav in Settings modal

### DIFF
--- a/src/client/styles/_tabs.scss
+++ b/src/client/styles/_tabs.scss
@@ -17,6 +17,8 @@
 }
 
 .tab-list {
+  position: sticky;
+  top: 25px;
   flex: 0 0 220px;
   height: 100%;
   padding-right: 1rem;


### PR DESCRIPTION
## Description

When opening the Settings Modal, the Tabs nav scrolled as the content. But as a user we were expecting that the Nav would be sticky.

Closes [issue #531](https://github.com/taniarascia/takenote/issues/531).

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari