### PR TITLE
New Feature : Star Icon get filled when note is favorite ⭐️

### DIFF
--- a/src/client/components/NoteList/ContextMenuOption.tsx
+++ b/src/client/components/NoteList/ContextMenuOption.tsx
@@ -8,13 +8,13 @@ export interface ContextMenuOptionProps {
   handler: MouseEventHandler & KeyboardEventHandler
   icon: Icon
   text: string
-  optionType?: string
+  className?: string
 }
 
 export const ContextMenuOption: React.FC<ContextMenuOptionProps> = ({
   dataTestID,
   handler,
-  optionType,
+  className = 'nav-item',
   icon: IconCmp,
   text,
   ...rest
@@ -39,7 +39,7 @@ export const ContextMenuOption: React.FC<ContextMenuOptionProps> = ({
   return (
     <div
       data-testid={dataTestID}
-      className={optionType === 'delete' ? 'nav-item delete-option' : 'nav-item'}
+      className={className}
       role="button"
       onClick={optionHandler}
       onKeyPress={optionHandler}

--- a/src/client/containers/ContextMenuOptions.tsx
+++ b/src/client/containers/ContextMenuOptions.tsx
@@ -85,7 +85,7 @@ const CategoryOptions: React.FC<CategoryOptionsProps> = ({ clickedCategory }) =>
         handler={removeCategoryHandler}
         icon={X}
         text={LabelText.DELETE_PERMANENTLY}
-        optionType="delete"
+        className="nav-item delete-option"
       />
     </nav>
   )
@@ -154,7 +154,7 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
             handler={deleteNotesHandler}
             icon={X}
             text={LabelText.DELETE_PERMANENTLY}
-            optionType="delete"
+            className="nav-item delete-option"
           />
           <ContextMenuOption
             dataTestID={TestID.NOTE_OPTION_RESTORE_FROM_TRASH}
@@ -169,6 +169,7 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
           <ContextMenuOption
             dataTestID={TestID.NOTE_OPTION_FAVORITE}
             handler={favoriteNoteHandler}
+            className={clickedNote.favorite ? 'nav-item favorite-option' : 'nav-item'}
             icon={Star}
             text={
               isSelectedNotesDiffFavor
@@ -183,7 +184,7 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
             handler={trashNoteHandler}
             icon={Trash}
             text={LabelText.MOVE_TO_TRASH}
-            optionType="delete"
+            className="nav-item delete-option"
           />
         </>
       )}

--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -102,6 +102,14 @@ export const NoteMenuBar = () => {
     _togglePreviewMarkdown()
   }
 
+  const determineStarButtonClass = () => {
+    if (activeNote.favorite) {
+      return 'note-menu-bar-button favorite'
+    } else {
+      return 'note-menu-bar-button'
+    }
+  }
+
   return (
     <section className="note-menu-bar">
       {activeNote && !isDraftNote(activeNote) ? (
@@ -120,7 +128,7 @@ export const NoteMenuBar = () => {
           </button>
           {!activeNote.scratchpad && (
             <>
-              <button className="note-menu-bar-button" onClick={favoriteNoteHandler}>
+              <button className={determineStarButtonClass()} onClick={favoriteNoteHandler}>
                 <Star aria-hidden="true" size={18} />
                 <span className="sr-only">Add note to favorites</span>
               </button>

--- a/src/client/styles/_dark.scss
+++ b/src/client/styles/_dark.scss
@@ -149,6 +149,9 @@ $dark-editor: #3f3f3f;
           color: white;
         }
       }
+      &.favorite-option svg {
+        fill: $attribute;
+      }
     }
   }
 

--- a/src/client/styles/_layout.scss
+++ b/src/client/styles/_layout.scss
@@ -110,6 +110,10 @@
       }
     }
 
+    &.favorite-option svg {
+      fill: $attribute;
+    }
+
     &.delete-option {
       &:hover {
         background: $error;

--- a/src/client/styles/_note-menu-bar.scss
+++ b/src/client/styles/_note-menu-bar.scss
@@ -49,6 +49,11 @@
     &:active svg {
       transform: scale(1.1);
     }
+
+    &.favorite svg {
+      fill: $attribute;
+    }
+
     &.uuid {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Description

For now, when we click on the Star icon to add a note to our favorites the star stay the same colour. Which is confusing because it doesn't show us that the note has been added to our favorites.

To solve this UX issue we just need to fill the star icon with an orange colour to tell the user that this note is one of our favorites.
 
![Enregistrement de l’écran 2021-11-14 à 11 23 55](https://user-images.githubusercontent.com/26710696/141677337-fcc4b548-b155-4e8e-aaa9-3e53aa36eae9.gif)

I've also add this behaviour to the contextual menu.

<img width="247" alt="Capture d’écran 2021-11-14 à 11 26 48" src="https://user-images.githubusercontent.com/26710696/141677370-22d2abf9-81d5-4a61-b9cb-f2698ca1dd50.png">

<img width="245" alt="Capture d’écran 2021-11-14 à 11 26 36" src="https://user-images.githubusercontent.com/26710696/141677372-cd50b34e-5cf7-4fae-92aa-eb009c0fc2af.png">

Closes [issue #511](https://github.com/taniarascia/takenote/issues/511).

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari

### Testing checklist

- [x] End-to-end tests have been created if necessary
