### PR TITLE
Feature addition: Color fill star icon when toggled to favorite

### DIFF
--- a/src/client/components/NoteList/ContextMenuOption.tsx
+++ b/src/client/components/NoteList/ContextMenuOption.tsx
@@ -1,6 +1,7 @@
 import React, { KeyboardEventHandler, MouseEventHandler, useContext } from 'react'
 import { Icon } from 'react-feather'
 
+import { starFillColor } from '@/utils/constants'
 import { MenuUtilitiesContext } from '@/containers/ContextMenu'
 
 export interface ContextMenuOptionProps {
@@ -46,7 +47,12 @@ export const ContextMenuOption: React.FC<ContextMenuOptionProps> = ({
       tabIndex={0}
       {...rest}
     >
-      <IconCmp className="nav-item-icon" size={18} />
+      {text.includes('Remove') ? (
+        <IconCmp className="nav-item-icon" fill={starFillColor} size={18} />
+      ) : (
+        <IconCmp className="nav-item-icon" size={18} />
+      )}
+      {/* <IconCmp className="nav-item-icon" size={18} /> */}
       {text}
     </div>
   )

--- a/src/client/containers/NoteList.tsx
+++ b/src/client/containers/NoteList.tsx
@@ -19,6 +19,7 @@ import {
 import { NoteItem, ReactDragEvent, ReactMouseEvent } from '@/types'
 import { getNotes, getSettings, getCategories } from '@/selectors'
 import { getNotesSorter } from '@/utils/notesSortStrategies'
+import { starFillColor } from '@/utils/constants'
 
 export const NoteList: React.FC = () => {
   // ===========================================================================
@@ -26,8 +27,9 @@ export const NoteList: React.FC = () => {
   // ===========================================================================
 
   const { notesSortKey } = useSelector(getSettings)
-  const { activeCategoryId, activeFolder, selectedNotesIds, notes, searchValue } =
-    useSelector(getNotes)
+  const { activeCategoryId, activeFolder, selectedNotesIds, notes, searchValue } = useSelector(
+    getNotes
+  )
   const { categories } = useSelector(getCategories)
 
   // ===========================================================================
@@ -214,7 +216,12 @@ export const NoteList: React.FC = () => {
                   {note.favorite ? (
                     <>
                       <div className="icon">
-                        <Star aria-hidden="true" className="note-favorite" size={12} />
+                        <Star
+                          aria-hidden="true"
+                          className="note-favorite"
+                          fill={starFillColor}
+                          size={12}
+                        />
                         <span className="sr-only">Favorite note</span>
                       </div>
                       <div className="truncate-text">{noteTitle}</div>

--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -27,6 +27,7 @@ import { toggleFavoriteNotes, toggleTrashNotes } from '@/slices/note'
 import { getCategories, getNotes, getSync, getSettings } from '@/selectors'
 import { downloadNotes, isDraftNote, getShortUuid, copyToClipboard } from '@/utils/helpers'
 import { sync } from '@/slices/sync'
+import { starFillColor } from '@/utils/constants'
 
 export const NoteMenuBar = () => {
   // ===========================================================================
@@ -47,6 +48,7 @@ export const NoteMenuBar = () => {
   const activeNote = notes.find((note) => note.id === activeNoteId)!
   const shortNoteUuid = getShortUuid(activeNoteId)
 
+  const isFavorite = notes.find((note) => note.id === activeNoteId)?.favorite
   // ===========================================================================
   // State
   // ===========================================================================
@@ -121,7 +123,11 @@ export const NoteMenuBar = () => {
           {!activeNote.scratchpad && (
             <>
               <button className="note-menu-bar-button" onClick={favoriteNoteHandler}>
-                <Star aria-hidden="true" size={18} />
+                {isFavorite ? (
+                  <Star aria-hidden="true" size={18} fill={starFillColor} />
+                ) : (
+                  <Star aria-hidden="true" size={18} />
+                )}
                 <span className="sr-only">Add note to favorites</span>
               </button>
               <button className="note-menu-bar-button trash" onClick={trashNoteHandler}>

--- a/src/client/utils/constants.ts
+++ b/src/client/utils/constants.ts
@@ -10,6 +10,8 @@ export const folderMap: Record<Folder, string> = {
 
 export const iconColor = 'rgba(255, 255, 255, 0.25)'
 
+export const starFillColor = 'rgba(255, 237, 38,1.0)'
+
 export const shortcutMap = [
   { action: 'Create a new note', key: 'N' },
   { action: 'Delete a note', key: 'U' },


### PR DESCRIPTION
## Description

The current version makes it difficult for the end-user to identify if a starred note is actually added to favorites or not, this is because there's no UI change when a note is starred from the bottom menu bar, this would make the user click the star option multiple times which is a bad UX. A simple fix would be to reflect the changes when a note is added/removed from favorites, like filling the star color when a note is toggled to be favorite, and remove the filling when it is removed from favorites.
This PR adds this feature to improve the  UX, and also this behavior is consistent across all the components (Bottom menu bar, Notes list and, context menu).
The toggle state is also accessed from the redux store(Where required) instead of having a separate function that determines the toggle state. Moreover, this is achieved, without having to make any changes or updates to the stylesheets, by making use of `fill` props of the icon.

Closes #511 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge

### Testing checklist

- [x] End-to-end tests have been created if necessary
