### PR TITLE
#559 separate line doesn't display in dark mode

### DIFF
--- a/src/client/styles/_dark.scss
+++ b/src/client/styles/_dark.scss
@@ -1,5 +1,6 @@
 $dark-sidebar: #333;
 $dark-editor: #3f3f3f;
+$dark-seperator: #777777;
 
 .dark {
   a {
@@ -203,7 +204,7 @@ $dark-editor: #3f3f3f;
     hr {
       height: 0;
       border: 0;
-      border-top: 2px solid darken($dark-editor, 5%);
+      border-top: 2px solid darken($dark-seperator, 5%);
     }
 
     blockquote {


### PR DESCRIPTION
## Description

it was a sass mini misconfig .. <hr /> had same color as background in dark.scss
created a new variable and give that a color
you can change the color to proper one later

Closes #559 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox

### Testing checklist

- [ ] End-to-end tests have been created if necessary
