### PR TITLE
558 edit preview icon

### DIFF
--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -52,7 +52,10 @@ export const NoteMenuBar = () => {
   // ===========================================================================
 
   const [uuidCopiedText, setUuidCopiedText] = useState<string>('')
-  const [isToggled, togglePreviewIcon] = useState<boolean>(false)
+
+  // not necessory to use another state here as we have previewMarkdown
+  // const [isToggled, togglePreviewIcon] = useState<boolean>(false)
+  const { previewMarkdown } = useSelector(getSettings)
 
   // ===========================================================================
   // Hooks
@@ -98,7 +101,7 @@ export const NoteMenuBar = () => {
     _updateCodeMirrorOption('theme', darkTheme ? 'base16-light' : 'new-moon')
   }
   const togglePreviewHandler = () => {
-    togglePreviewIcon(!isToggled)
+    // togglePreviewIcon(!isToggled)
     _togglePreviewMarkdown()
   }
 
@@ -111,12 +114,12 @@ export const NoteMenuBar = () => {
             onClick={togglePreviewHandler}
             data-testid={TestID.PREVIEW_MODE}
           >
-            {isToggled ? (
+            {previewMarkdown ? (
               <Edit aria-hidden="true" size={18} />
             ) : (
               <Eye aria-hidden="true" size={18} />
             )}
-            <span className="sr-only">{isToggled ? 'Edit note' : 'Preview note'}</span>
+            <span className="sr-only">{previewMarkdown ? 'Edit note' : 'Preview note'}</span>
           </button>
           {!activeNote.scratchpad && (
             <>

--- a/src/client/styles/_dark.scss
+++ b/src/client/styles/_dark.scss
@@ -1,5 +1,6 @@
 $dark-sidebar: #333;
 $dark-editor: #3f3f3f;
+$dark-seperator: #777777;
 
 .dark {
   a {
@@ -203,7 +204,7 @@ $dark-editor: #3f3f3f;
     hr {
       height: 0;
       border: 0;
-      border-top: 2px solid darken($dark-editor, 5%);
+      border-top: 2px solid darken($dark-seperator, 5%);
     }
 
     blockquote {

--- a/src/client/utils/helpers.ts
+++ b/src/client/utils/helpers.ts
@@ -161,6 +161,7 @@ export const newNoteHandlerHelper = (
     swapFolder(Folder.ALL)
   }
 
+  console.log(previewMarkdown)
   if (previewMarkdown) {
     togglePreviewMarkdown()
   }


### PR DESCRIPTION
## Description

extra state was mixing things up
remove isToggle and work with previewMarkdown as state of the markdown and edit button
works perfect now.

Closes #558

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
