### PR TITLE
Fixed Dark Mode preview functionality

### DIFF
--- a/src/client/styles/_dark.scss
+++ b/src/client/styles/_dark.scss
@@ -220,6 +220,10 @@ $dark-editor: #3f3f3f;
     }
   }
 
+  .previewer > * {
+    color: white;
+  }
+
   .settings-modal {
     background: $dark-sidebar;
     color: $light-font-color;


### PR DESCRIPTION
## Description

Fixed the dark mode functionality error of the texts. Changed background of letters from black to white when switched to dark mode.

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
