### PR TITLE
Added icons Hover color

### DIFF
--- a/src/client/containers/NoteMenuBar.tsx
+++ b/src/client/containers/NoteMenuBar.tsx
@@ -107,7 +107,7 @@ export const NoteMenuBar = () => {
       {activeNote && !isDraftNote(activeNote) ? (
         <nav>
           <button
-            className="note-menu-bar-button"
+            className="note-menu-bar-button eye"
             onClick={togglePreviewHandler}
             data-testid={TestID.PREVIEW_MODE}
           >
@@ -120,7 +120,7 @@ export const NoteMenuBar = () => {
           </button>
           {!activeNote.scratchpad && (
             <>
-              <button className="note-menu-bar-button" onClick={favoriteNoteHandler}>
+              <button className="note-menu-bar-button star" onClick={favoriteNoteHandler}>
                 <Star aria-hidden="true" size={18} />
                 <span className="sr-only">Add note to favorites</span>
               </button>
@@ -130,12 +130,12 @@ export const NoteMenuBar = () => {
               </button>
             </>
           )}
-          <button className="note-menu-bar-button">
+          <button className="note-menu-bar-button download">
             <Download aria-hidden="true" size={18} onClick={downloadNotesHandler} />
             <span className="sr-only">Download note</span>
           </button>
           <button
-            className="note-menu-bar-button uuid"
+            className="note-menu-bar-button uuid icon-hover"
             onClick={() => {
               copyToClipboard(`{{${shortNoteUuid}}}`)
               setUuidCopiedText(successfulCopyMessage)
@@ -153,7 +153,7 @@ export const NoteMenuBar = () => {
       <nav>
         <LastSyncedNotification datetime={lastSynced} pending={pendingSync} syncing={syncing} />
         <button
-          className="note-menu-bar-button"
+          className="note-menu-bar-button reload"
           onClick={syncNotesHandler}
           data-testid={TestID.TOPBAR_ACTION_SYNC_NOTES}
         >
@@ -164,12 +164,12 @@ export const NoteMenuBar = () => {
           )}
           <span className="sr-only">Sync notes</span>
         </button>
-        <button className="note-menu-bar-button" onClick={toggleDarkThemeHandler}>
+        <button className="note-menu-bar-button moon" onClick={toggleDarkThemeHandler}>
           {darkTheme ? <Sun aria-hidden="true" size={18} /> : <Moon aria-hidden="true" size={18} />}
           <span className="sr-only">Themes</span>
         </button>
 
-        <button className="note-menu-bar-button" onClick={settingsHandler}>
+        <button className="note-menu-bar-button setting" onClick={settingsHandler}>
           <Settings aria-hidden="true" size={18} />
           <span className="sr-only">Settings</span>
         </button>

--- a/src/client/styles/_note-menu-bar.scss
+++ b/src/client/styles/_note-menu-bar.scss
@@ -52,6 +52,39 @@
     &.uuid {
       display: flex;
       align-items: center;
+      &:hover {
+        color: $note-icon-color;
+      }
+    }
+    &.star {
+      &:hover {
+        color: $yellow;
+      }
+    }
+    &.eye {
+      &:hover {
+        color: $primary;
+      }
+    }
+    &.download {
+      &:hover {
+        color: $download-icon-color;
+      }
+    }
+    &.moon {
+      &:hover {
+        color: $moon-icon;
+      }
+    }
+    &.reload {
+      &:hover {
+        color: $reload-icon-color;
+      }
+    }
+    &.setting {
+      &:hover {
+        color: lighten($primary, 10%);
+      }
     }
   }
 

--- a/src/client/styles/_variables.scss
+++ b/src/client/styles/_variables.scss
@@ -50,3 +50,8 @@ $attribute: #ffd479;
 $class: #e1a6f2;
 $tag: #6ab0f3;
 $error: #f2777a;
+$yellow: #ffd700;
+$download-icon-color: #2cc56d;
+$note-icon-color: #08475e;
+$reload-icon-color: #f17017;
+$moon-icon: #ebd28b;


### PR DESCRIPTION
## Description

Added the tint to the Hover effect action of all note icons. Made it consistent along with the trash icon to improve the user experience.

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Testing checklist

- [ ] End-to-end tests have been created if necessary
