### PR TITLE
Add bold transformation to menu options

### DIFF
--- a/src/resources/LabelText.ts
+++ b/src/resources/LabelText.ts
@@ -27,4 +27,5 @@ export enum LabelText {
   IMPORT_BACKUP = 'Import backup',
   TOGGLE_FAVORITE = 'Toggle favorite',
   COPY_REFERENCE_TO_NOTE = 'Copy reference to note',
+  DONT_PANIC = "Don't panic",
 }

--- a/src/resources/TestID.ts
+++ b/src/resources/TestID.ts
@@ -55,4 +55,5 @@ export enum TestID {
   LAST_SYNCED_NOTIFICATION_SYNCING = 'last-synced-notification-syncing',
   LAST_SYNCED_NOTIFICATION_UNSAVED = 'last-synced-notification-unsaved',
   LAST_SYNCED_NOTIFICATION_DATE = 'last-synced-notification-date',
+  DONT_PANIC = "Don't panic",
 }


### PR DESCRIPTION
## Potential improvements:

- Almost every container renders a set of functional components from /components dir. I would change the structure to something like:

  - /components
     - ./AppSidebar
          index.tsx
          ...other components

which I find easier to browse, at least for me.

- Make it easier to write styles, by moving those that directly affect an existent component. Keep the entry file to import global variables like colors, grid... 