### PR TITLE
Added required node version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ DEMO=true
 
 ### Installation
 
+You need Node 14 to run this app
+
 ```bash
 git clone git@github.com:taniarascia/takenote
 cd takenote


### PR DESCRIPTION
## Description

This is a fix for https://github.com/taniarascia/takenote/issues/612. This is an issue for people on node version other than 14 as they wont be able to install npm packages like node-sass which require version 14. 

Closes #612 

### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari

### Testing checklist

- [x] End-to-end tests have been created if necessary
